### PR TITLE
Change account page behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@density/ui": "4.9.0",
         "d3": "5.1.0",
         "moment": "2.22.1",
-        "moment-timezone": "0.5.14"
+        "moment-timezone": "0.5.16"
       },
       "dependencies": {
         "d3": {
@@ -364,9 +364,9 @@
       "integrity": "sha1-8NCxiYn30lpKPSIf//apr33jBu8="
     },
     "@density/ui-toast": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@density/ui-toast/-/ui-toast-0.1.1.tgz",
-      "integrity": "sha1-y2HYVpzlUXjnBf849Ky+6qqzd+Q="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@density/ui-toast/-/ui-toast-1.0.1.tgz",
+      "integrity": "sha512-2upZc7X+p0PG5Qo1x2bXxIkNvgwer/o9S78AUDYoQ0y4Nx/rmcnKwdUWyxTGGPGjCYJMlYMTRAqIDN4Z20p1og=="
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@density/ui-percentage-bar": "0.0.1",
     "@density/ui-popover": "^0.2.3",
     "@density/ui-radio-button": "^0.0.1",
-    "@density/ui-toast": "^0.1.1",
+    "@density/ui-toast": "^1.0.1",
     "classnames": "^2.2.5",
     "debug": "^3.1.0",
     "ent": "^2.2.0",

--- a/src/actions/user/reset-password.js
+++ b/src/actions/user/reset-password.js
@@ -1,26 +1,34 @@
 import { accounts } from '../../client';
 import sessionTokenSet from '../session-token/set';
+import userError from './error';
 
 export const USER_RESET_PASSWORD = 'USER_RESET_PASSWORD';
 export const USER_RESET_PASSWORD_SUCCESS = 'USER_RESET_PASSWORD_SUCCESS';
 
 export default function userResetPassword(current, password) {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     dispatch({ type: USER_RESET_PASSWORD, password });
 
-    // Set the new password.
-    return accounts.users.password({
-      old_password: current,
-      new_password: password,
-      confirm_password: password,
-    }).then(() => {
+    try {
+      // Set the new password.
+      await accounts.users.password({
+        old_password: current,
+        new_password: password,
+        confirm_password: password,
+      });
+
       // Fetch a new access token with new password.
-      return accounts.users.login({email: getState().user.email, password})
-    }).then(token => {
+      const token = await accounts.users.login({
+        email: getState().user.data.email,
+        password,
+      });
       dispatch(sessionTokenSet(token));
 
       // Report success.
       dispatch({ type: USER_RESET_PASSWORD_SUCCESS });
-    });
+    } catch (err) {
+      // Failure while resetting password.
+      dispatch(userError(err));
+    }
   };
 }

--- a/src/components/account/_styles.scss
+++ b/src/components/account/_styles.scss
@@ -71,3 +71,25 @@
   flex: 1;
   margin-bottom: 40px;
 }
+
+
+.account-password-reset-icon {
+  font-family: Densicons;
+  font-size: 18px;
+}
+
+.account-password-reset-toast {
+  margin-top: 70px;
+}
+@media (min-width: $screen-xs-max) {
+  .account-password-reset-toast {
+    margin-top: 0px;
+
+    position: absolute;
+    z-index: 1000;
+    top: 120px;
+
+    max-width: 420px;
+    left: calc(50% - 210px);
+  }
+}

--- a/src/components/account/index.js
+++ b/src/components/account/index.js
@@ -64,9 +64,9 @@ export class Account extends React.Component {
         <Toast
           type="success"
           icon={<span className="account-password-reset-icon">&#xe908;</span>}
+          title="Password updated!"
           onDismiss={this.props.onHideSuccessToast}
         >
-          <div className="account-setup-doorway-list-success-toast-header" role="heading">Password updated!</div>
           Your password has been successfully updated.
         </Toast>
       </div> : null}

--- a/src/components/account/test.js
+++ b/src/components/account/test.js
@@ -17,9 +17,10 @@ const user = {
 };
 
 describe('Accounts page', function() {
-  it('by default shows the name, email, and password reset linke', function() {
+  it('by default shows the name, email, and password reset links', function() {
     const component = mount(<Account
-      initialUser={user}
+      user={user}
+      activeModal={{name: null}}
     />);
 
     // Always show name and email inputs
@@ -38,7 +39,8 @@ describe('Accounts page', function() {
   });
   it('shows the password reset form after clicking the password reset link', function() {
     const component = mount(<Account
-      initialUser={user}
+      user={user}
+      activeModal={{name: null}}
     />);
 
     // Click change password
@@ -60,7 +62,8 @@ describe('Accounts page', function() {
   });
   it('makes the name / email editable when the user clicks the edit button', function() {
     const component = mount(<Account
-      initialUser={user}
+      user={user}
+      activeModal={{name: null}}
     />);
 
     // Click change password
@@ -79,9 +82,34 @@ describe('Accounts page', function() {
     // Show submit user details button
     assert.notEqual(component.find('.account-submit-user-details button').length, 0);
   });
+  it('resets the state of name back to original state when cancel is clicked', function() {
+    const component = mount(<Account
+      user={user}
+      activeModal={{name: null}}
+    />);
+
+    // Click "edit" link
+    component.find('.account-edit-button').simulate('click');
+
+    // Ensure fullname and nickname inputs are visible
+    assert.equal(component.find('.account-full-name-container input').prop('disabled'), false);
+    assert.equal(component.find('.account-nickname-container input').prop('disabled'), false);
+
+    // Change contents of nickname
+    component.find('.account-nickname-container input').simulate('change', {
+      target: {value: 'something else'},
+    });
+
+    // Click cancel
+    component.find('.account-edit-button').simulate('click');
+
+    // Ensure that the original value is in the box
+    assert.equal(component.find('.account-nickname-container input').prop('value'), user.nickname);
+  });
   it('sets the nickname to the best guess from the full name', function() {
     const component = mount(<Account
-      initialUser={user}
+      user={user}
+      activeModal={{name: null}}
     />);
 
     // Name defaults to 'Nickname'
@@ -99,10 +127,13 @@ describe('Accounts page', function() {
     const component = mount(<Provider store={store}><ConnectedAccount /></Provider>);
 
     // Make sure a loading indicator is visible.
-    assert.equal(component.find('.loading-spinner').length, 1);
+    assert.equal(component.find('.card-loading').length, 1);
   });
   it('shows a error bar when there is an error', function() {
-    const component = mount(<Account initialUser={user} />);
+    const component = mount(<Account
+      user={user}
+      activeModal={{name: null}}
+    />);
 
     // Set an error.
     component.setState({error: 'boom!'});

--- a/src/helpers/websocket-event-pusher/index.js
+++ b/src/helpers/websocket-event-pusher/index.js
@@ -43,8 +43,8 @@ export default class WebsocketEventPusher extends EventEmitter {
     // If connected already, close the connection before connecting again.
     if (this.connectionState === CONNECTION_STATES.CONNECTED) {
       this.log('   ... SOCKET IS ALREADY CONNECTED, DISCONNECTING...');
+      this.gracefulDisconnect = true;
       this.disconnect();
-      this.gracefulDisconnect = false;
     }
 
     // Ensure that only one connection can occur at a time.
@@ -97,7 +97,7 @@ export default class WebsocketEventPusher extends EventEmitter {
 
       // When the connection disconnects, reconnect after a delay.
       this.socket.onclose = () => {
-        this.log('SOCKET CLOSE');
+        this.log('SOCKET CLOSE', this.gracefulDisconnect);
         this.emit('disconnect');
 
         // Clear the interval that sends a ping to the sockets server if it is open.

--- a/src/reducers/user/index.js
+++ b/src/reducers/user/index.js
@@ -13,9 +13,9 @@ const initialState = {
 export function user(state=initialState, action) {
   switch (action.type) {
   case USER_SET:
-    return {...state, data: objectSnakeToCamel(action.data)};
+    return {...state, loading: false, data: objectSnakeToCamel(action.data)};
   case USER_PUSH:
-    return {...state, data: {...state.user, ...objectSnakeToCamel(action.item)}};
+    return {...state, loading: false, data: {...state.user, ...objectSnakeToCamel(action.item)}};
   default:
     return state;
   }

--- a/src/reducers/user/index.js
+++ b/src/reducers/user/index.js
@@ -5,7 +5,7 @@ import objectSnakeToCamel from '../../helpers/object-snake-to-camel/index';
 import mixpanelUserReducerEnhancer from '../../helpers/mixpanel-user-reducer-enhancer/index';
 
 const initialState = {
-  user: null,
+  data: null,
   loading: true,
   error: false,
 };
@@ -15,7 +15,7 @@ export function user(state=initialState, action) {
   case USER_SET:
     return {...state, loading: false, data: objectSnakeToCamel(action.data)};
   case USER_PUSH:
-    return {...state, loading: false, data: {...state.user, ...objectSnakeToCamel(action.item)}};
+    return {...state, loading: false, data: {...state.data, ...objectSnakeToCamel(action.item)}};
   default:
     return state;
   }

--- a/src/reducers/user/test.js
+++ b/src/reducers/user/test.js
@@ -13,4 +13,9 @@ describe('user', function() {
     const output = user({user: {foo: 'bar'}}, userPush({email: 'test@density.io'}));
     assert.deepEqual(output.data, {foo: 'bar', email: 'test@density.io'});
   });
+
+  it('should fully update the user inside and reset loading state', function() {
+    const output = user({loading: true}, userSet({email: 'test@density.io'}));
+    assert.deepEqual(output.loading, false);
+  });
 });

--- a/src/reducers/user/test.js
+++ b/src/reducers/user/test.js
@@ -10,7 +10,7 @@ describe('user', function() {
     assert.deepEqual(output.data, {email: 'test@density.io'});
   });
   it('should apply a single field update to a user', function() {
-    const output = user({user: {foo: 'bar'}}, userPush({email: 'test@density.io'}));
+    const output = user({data: {foo: 'bar'}}, userPush({email: 'test@density.io'}));
     assert.deepEqual(output.data, {foo: 'bar', email: 'test@density.io'});
   });
 


### PR DESCRIPTION
Was doing some investigation into some of the websockets issues we've found, and discovered some issues with the accounts page.

This PR addresses a few bugs:
- Canceling form after clicking edit resets the form back to the initial state, and rejects the edits (previously this wasn't being done). Test added to cover this.
- Changing password was causing a websocket infinite loop
  - Effectively, this caused the token in the websocket event pusher module to not be updated in a graceful fashion.
- Change password toast shows properly and is dismissable
  - Required some Density UI updates to make that happen, which are here: https://github.com/DensityCo/ui/pull/18
- In addition, as part of DEN-4528, fixed up and wrote some tests to ensure that the account page was handling errors properly.

DEN-4528