### PR TITLE
Ensure that utilization chart never overflows its bounds

### DIFF
--- a/src/components/insights-space-detail-utilization-card/index.js
+++ b/src/components/insights-space-detail-utilization-card/index.js
@@ -433,7 +433,14 @@ export default class InsightsSpaceDetailUtilizationCard extends React.Component 
                 formatter: ({value}) => value === 100 ? '100%' : `${value}`,
               })}
               yAxisStart={0}
-              yAxisEnd={100}
+
+              // The largest point on the y axis should either be:
+              // 1. The largest point on the graph, if larger than 100. (+ 10% in spacing)
+              // 2. 100.
+              yAxisEnd={Math.max(
+                Math.max.apply(Math, averageUtilizationDatapointsWithTimestamp.map(i => i.value))+10, /* 1 */
+                100 /* 2 */
+              )}
 
               overlays={[
                 overlayTwoPopups({


### PR DESCRIPTION
Previously, the utilization chart's y axis would always be bounded from `0%` to `100%`. There's a problem with that though if the utilization peaks for a space above `100%`:

![screen shot 2018-05-02 at 12 33 01 pm](https://user-images.githubusercontent.com/1704236/39537031-539db2d2-4e06-11e8-9678-b1fb13f8524d.png)

This PR adds logic to ensure that the largest point on the y axis should either be:
```
1. The largest point on the graph, if larger than 100. (+ 10% in spacing)
2. 100.
```