### PR TITLE
Sockets reconnect Instability

### DIFF
--- a/src/helpers/websocket-event-pusher/index.js
+++ b/src/helpers/websocket-event-pusher/index.js
@@ -102,7 +102,7 @@ export default class WebsocketEventPusher extends EventEmitter {
 
         // Clear the interval that sends a ping to the sockets server if it is open.
         if (this.pingIntervalId) {
-          window.clearTimeout(this.pingIntervalId);
+          window.clearInterval(this.pingIntervalId);
         }
 
         if (this.gracefulDisconnect) {
@@ -111,7 +111,7 @@ export default class WebsocketEventPusher extends EventEmitter {
           return;
         }
 
-        // We're not gracefulyl disconnecting, so try to reconnect.
+        // We're not gracefully disconnecting, so try to reconnect.
 
         // Calculate the timeout before the next reconnect attempt. Use an exponential backoff.
         const backoffTimeout = MINIMUM_CONNECTION_INTERVAL + (Math.pow(iteration, 2) * 1000);

--- a/src/helpers/websocket-event-pusher/index.js
+++ b/src/helpers/websocket-event-pusher/index.js
@@ -6,7 +6,7 @@ import debug from 'debug';
 import { core } from '../../client';
 
 // If disconnected, try to connect at minimum this often.
-const MINIMUM_CONNECTION_INTERVAL = 1000;
+const MINIMUM_CONNECTION_INTERVAL = 500;
 
 // Every 60 seconds, send a ping on the websocket connection. This is to ensure that it stays open.
 const WEBSOCKET_PING_MESSAGE_INTERVAL_IN_SECONDS = 60 * 1000;
@@ -42,9 +42,8 @@ export default class WebsocketEventPusher extends EventEmitter {
 
     // If connected already, close the connection before connecting again.
     if (this.connectionState === CONNECTION_STATES.CONNECTED) {
-      this.log('   ... SOCKET IS ALREADY CONNECTED, DISCONNECTING...');
-      this.gracefulDisconnect = true;
-      this.disconnect();
+      this.log('   ... SOCKET IS ALREADY CONNECTED');
+      return false;
     }
 
     // Ensure that only one connection can occur at a time.
@@ -97,6 +96,7 @@ export default class WebsocketEventPusher extends EventEmitter {
 
       // When the connection disconnects, reconnect after a delay.
       this.socket.onclose = () => {
+        this.connectionState = CONNECTION_STATES.CLOSED;
         this.log('SOCKET CLOSE', this.gracefulDisconnect);
         this.emit('disconnect');
 
@@ -107,6 +107,7 @@ export default class WebsocketEventPusher extends EventEmitter {
 
         if (this.gracefulDisconnect) {
           this.log('   ... GRACEFULLY DISCONNECTING');
+          this.gracefulDisconnect = false;
           return;
         }
 


### PR DESCRIPTION
If the connectionState isn't reset, then attempting to reconnect again
will disconnect the already disconnected connection before reconnection,
which isn't ideal.