### PR TITLE
Fix error banner width on login page

### DIFF
--- a/src/components/login/_styles.scss
+++ b/src/components/login/_styles.scss
@@ -1,4 +1,4 @@
-
+$login-section-width: 420px;
 .login-section {
   margin: 0px auto;
 
@@ -6,7 +6,7 @@
   padding-left: 5px;
   padding-right: 5px;
   @media (min-width: 450px) {
-    width: 420px;
+    width: $login-section-width;
     padding-left: 30px;
     padding-right: 30px;
   }
@@ -56,6 +56,7 @@
   position: absolute;
   top: 61px;
   z-index: 2000;
+  width: $login-section-width;
 }
 .login-toast-header {
   color: $brand-danger;


### PR DESCRIPTION
It looks like at some point a static width was removed from the login
page error toast container. Add it back in.

![screen shot 2018-06-18 at 10 25 14 am](https://user-images.githubusercontent.com/1704236/41542014-eb1baff6-72e1-11e8-9c81-ebc4e777baf9.png)
