### PR TITLE
Dashboard changes to support demo account

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -700,9 +700,9 @@
       }
     },
     "@density/ui-navbar": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@density/ui-navbar/-/ui-navbar-2.4.3.tgz",
-      "integrity": "sha1-Jvr+1HhxH7AyMb8CtzeWgjKHC9o=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@density/ui-navbar/-/ui-navbar-2.5.1.tgz",
+      "integrity": "sha512-IggubhxPfFfMMFcP44OzKC5nd2e7WRSOX+pJ1Yf7qllzqeLaTQiTpwC0owYbEartuYLnRO2tLHj6vDh7EeNu0A==",
       "requires": {
         "classnames": "2.2.5"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@density/ui-input-box": "^2.1.0",
     "@density/ui-input-stack": "0.2.0",
     "@density/ui-modal": "^0.3.1",
-    "@density/ui-navbar": "^2.4.3",
+    "@density/ui-navbar": "^2.5.1",
     "@density/ui-navbar-sidebar": "0.1.3",
     "@density/ui-pager-button-group": "^0.1.5",
     "@density/ui-percentage-bar": "0.0.1",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -7,19 +7,25 @@ let store;
 function setStore(s) { store = s; }
 
 async function errorHandler(response) {
-  const data = await response.json();
+  try {
+    const data = await response.json();
 
-  // If the user received a 403 with a body of 'invalid authentication credentials' in response to
-  // any request, send them to the login page.  Redirect the user to the login page and remove the
-  // bad session token from the reducer.
-  if (response.status === 403 && data.detail === 'Incorrect authentication credentials.') {
-    store.dispatch(userError(`Login session has expired or is invalid. Please login again.`));
-    store.dispatch(sessionTokenUnSet());
-    window.location.href = '#/login';
+    // If the user received a 403 with a body of 'invalid authentication credentials' in response to
+    // any request, send them to the login page.  Redirect the user to the login page and remove the
+    // bad session token from the reducer.
+    if (response.status === 403 && data.detail === 'Incorrect authentication credentials.') {
+      store.dispatch(userError(`Login session has expired or is invalid. Please login again.`));
+      store.dispatch(sessionTokenUnSet());
+      window.location.href = '#/login';
+    }
+
+    // If the response wasn't a 403, then return the best representation of the error.
+    return data.detail || data.error || JSON.stringify(data);
+  } catch (err) {
+    // Handle requests that don't contain json.
+    const text = await response.text();
+    return text;
   }
-
-  // If the response wasn't a 403, then return the best representation of the error.
-  return data.detail || data.error || JSON.stringify(data);
 }
 
 const core = clientele({...require('./specs/core-api'), errorFormatter: errorHandler});

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -7,17 +7,18 @@ let store;
 function setStore(s) { store = s; }
 
 async function errorHandler(response) {
-  // If the user received a 403 in response to any request, send them to the login page.
-  // Redirect the user to the login page and remove the bad session token from
-  // the reducer.
-  if (response.status === 403) {
+  const data = await response.json();
+
+  // If the user received a 403 with a body of 'invalid authentication credentials' in response to
+  // any request, send them to the login page.  Redirect the user to the login page and remove the
+  // bad session token from the reducer.
+  if (response.status === 403 && data.detail === 'Incorrect authentication credentials.') {
     store.dispatch(userError(`Login session has expired or is invalid. Please login again.`));
     store.dispatch(sessionTokenUnSet());
     window.location.href = '#/login';
   }
 
   // If the response wasn't a 403, then return the best representation of the error.
-  const data = await response.json();
   return data.detail || data.error || JSON.stringify(data);
 }
 

--- a/src/components/account/index.js
+++ b/src/components/account/index.js
@@ -31,17 +31,17 @@ export class Account extends React.Component {
       passwordConfirmation: '',
 
       // Initialize with a prop passing the initial value from the store
-      fullName: this.props.user ? this.props.user.fullName : '',
-      nickname: this.props.user ? this.props.user.nickname : '',
-      email: this.props.user ? this.props.user.email : '',
+      fullName: this.props.user.data ? this.props.user.data.fullName : '',
+      nickname: this.props.user.data ? this.props.user.data.nickname : '',
+      email: this.props.user.data ? this.props.user.data.email : '',
     };
   }
 
   componentWillReceiveProps(nextProps) {
     this.setState({
-      fullName: nextProps.user.fullName || '',
-      nickname: nextProps.user.nickname || '',
-      email: nextProps.user.email || '',
+      fullName: nextProps.user.data.fullName || '',
+      nickname: nextProps.user.data.nickname || '',
+      email: nextProps.user.data.email || '',
     });
   }
 
@@ -77,7 +77,7 @@ export class Account extends React.Component {
           {this.state.mode === EDIT ? 'Edit Account' : 'Account'}
 
           {/* Edit / Cancel button */}
-          {user && !user.isDemo ? <ModalHeaderActionButton
+          {user.data && !user.data.isDemo ? <ModalHeaderActionButton
             onClick={() => {
               // If currently in edit mode, then reset all edits before transitioning back to normal
               // mode.
@@ -86,9 +86,9 @@ export class Account extends React.Component {
                   mode: NORMAL,
 
                   // Reset back to the values in the user prop (what's in redux)
-                  fullName: this.props.user.fullName || '',
-                  nickname: this.props.user.nickname || '',
-                  email: this.props.user.email || '',
+                  fullName: user.data.fullName || '',
+                  nickname: user.data.nickname || '',
+                  email: user.data.email || '',
                 });
               } else {
                 this.setState({mode: EDIT});
@@ -149,7 +149,7 @@ export class Account extends React.Component {
             label="Organization"
             input={<InputBox
               type="text"
-              value={user && user.organization ? user.organization.name : '(unknown organization)'}
+              value={user.data && user.data.organization ? user.data.organization.name : '(unknown organization)'}
               onChange={e => this.setState({email: e.target.value})}
               disabled={true}
               id="account-organization"
@@ -157,7 +157,7 @@ export class Account extends React.Component {
           />
 
           {/* Trigger changing the password */}
-          {this.state.mode === NORMAL && user && !user.isDemo ? <FormLabel
+          {this.state.mode === NORMAL && user.data && !user.data.isDemo ? <FormLabel
             className="account-change-password-link-container"
             label="Password"
             htmlFor="account-change-password"
@@ -226,7 +226,7 @@ export class Account extends React.Component {
 
 export default connect(state => {
   return {
-    user: state.user.data,
+    user: state.user,
     activeModal: state.activeModal,
     loading: state.user.loading,
   };

--- a/src/components/account/index.js
+++ b/src/components/account/index.js
@@ -77,7 +77,7 @@ export class Account extends React.Component {
           {this.state.mode === EDIT ? 'Edit Account' : 'Account'}
 
           {/* Edit / Cancel button */}
-          <ModalHeaderActionButton
+          {user && !user.isDemo ? <ModalHeaderActionButton
             onClick={() => {
               // If currently in edit mode, then reset all edits before transitioning back to normal
               // mode.
@@ -95,7 +95,7 @@ export class Account extends React.Component {
               }
             }}
             className="account-edit-button"
-          >{this.state.mode === EDIT ? 'Cancel' : 'Edit'}</ModalHeaderActionButton>
+          >{this.state.mode === EDIT ? 'Cancel' : 'Edit'}</ModalHeaderActionButton> : null}
         </CardHeader>
 
         <CardBody>
@@ -157,12 +157,12 @@ export class Account extends React.Component {
           />
 
           {/* Trigger changing the password */}
-          {this.state.mode === NORMAL ? <FormLabel
+          {this.state.mode === NORMAL && user && !user.isDemo ? <FormLabel
             className="account-change-password-link-container"
             label="Password"
             htmlFor="account-change-password"
             input={ <div id="account-change-password" className="account-change-password-value">
-              <span onClick={() => this.setState({mode: PASSWORD_RESET})}>Change Password</span>
+              <span onClick={() => this.setState({mode: PASSWORD_RESET})}>Change a Password</span>
             </div>}
           /> : null}
 

--- a/src/components/account/index.js
+++ b/src/components/account/index.js
@@ -162,7 +162,7 @@ export class Account extends React.Component {
             label="Password"
             htmlFor="account-change-password"
             input={ <div id="account-change-password" className="account-change-password-value">
-              <span onClick={() => this.setState({mode: PASSWORD_RESET})}>Change a Password</span>
+              <span onClick={() => this.setState({mode: PASSWORD_RESET})}>Change Password</span>
             </div>}
           /> : null}
 

--- a/src/components/account/test.js
+++ b/src/components/account/test.js
@@ -9,11 +9,13 @@ import storeFactory from '../../store';
 import ConnectedAccount, { Account, NORMAL, EDIT, PASSWORD_RESET } from './index';
 
 const user = {
-  fullName: 'foo',
-  nickname: 'bar',
-  email: 'foo@density.io',
-  organization: {
-    name: 'baz',
+  data: {
+    fullName: 'foo',
+    nickname: 'bar',
+    email: 'foo@density.io',
+    organization: {
+      name: 'baz',
+    },
   },
 };
 
@@ -105,7 +107,7 @@ describe('Accounts page', function() {
     component.find('.account-edit-button').simulate('click');
 
     // Ensure that the original value is in the box
-    assert.equal(component.find('.account-nickname-container input').prop('value'), user.nickname);
+    assert.equal(component.find('.account-nickname-container input').prop('value'), user.data.nickname);
   });
   it('sets the nickname to the best guess from the full name', function() {
     const component = mount(<Account

--- a/src/components/dev-token-update-modal/_styles.scss
+++ b/src/components/dev-token-update-modal/_styles.scss
@@ -24,3 +24,8 @@
 .token-update-destroy-submit {
   background-color: $brand-danger;
 }
+
+.token-update-description-field {
+  resize: none;
+  height: 5em;
+}

--- a/src/components/dev-token-update-modal/index.js
+++ b/src/components/dev-token-update-modal/index.js
@@ -99,8 +99,8 @@ export default class TokenUpdateModal extends React.Component {
 
             <p>
               The act of removing a token is irreversible - ie, you might have the token built into
-              a piece of software that might be difficult to reassign. Type in the
-              name of this token below (<code>{this.state.name}</code>) to remove.
+              a piece of software such that it would be difficult to reassign. Type in the name of
+              this token below (<code>{this.state.name}</code>) to remove.
             </p>
 
             <div className="token-update-destroy-confirmation">

--- a/src/components/dev-token-update-modal/index.js
+++ b/src/components/dev-token-update-modal/index.js
@@ -53,8 +53,9 @@ export default class TokenUpdateModal extends React.Component {
               label="Description"
               htmlFor="update-token-description"
               input={<InputBox
-                type="text"
-                id="update-token-description"
+                type="textarea"
+                className="token-update-description-field"
+                id="token-update-description"
                 value={this.state.description}
                 onChange={e => this.setState({description: e.target.value})}
               />}
@@ -98,7 +99,7 @@ export default class TokenUpdateModal extends React.Component {
 
             <p>
               The act of removing a token is irreversible - ie, you might have the token built into
-              a compiled thing somewhere that would be hard / impossible to reassign. Type in the
+              a piece of software that might be difficult to reassign. Type in the
               name of this token below (<code>{this.state.name}</code>) to remove.
             </p>
 

--- a/src/components/dev-webhook-list/index.js
+++ b/src/components/dev-webhook-list/index.js
@@ -62,7 +62,7 @@ export function WebhookList({
   </Subnav>;
 
   if (webhooks.loading) {
-    return <div className="webhook-list">
+    return <div className="webhook">
       {modals}
       {subnav}
       <div className="webhook-list-loading"><LoadingSpinner /></div>
@@ -83,7 +83,7 @@ export function WebhookList({
           <h1 className="webhook-list-header-text">Webhooks</h1>
           <DescriptionModal>
             <p>
-              Webhooks allow us to push you data whenever your Density sensors count an event. Create a webhook, tell us what endpoint to hit, and we'll send you a payload over HTTP.
+              Webhooks allow us to push your data whenever your Density sensors count an event. Create a webhook, tell us what endpoint to hit, and we'll send you a payload over HTTP.
             </p>
             <a
               className="webhook-list-description-link"

--- a/src/components/dev-webhook-list/index.js
+++ b/src/components/dev-webhook-list/index.js
@@ -83,7 +83,7 @@ export function WebhookList({
           <h1 className="webhook-list-header-text">Webhooks</h1>
           <DescriptionModal>
             <p>
-              Webhooks allow us to push your data whenever your Density sensors count an event. Create a webhook, tell us what endpoint to hit, and we'll send you a payload over HTTP.
+              Webhooks allow us to push your data whenever your Density sensors count an event. Create a webhook, tell us what endpoint to hit, and we'll send you a HTTP request for each event.
             </p>
             <a
               className="webhook-list-description-link"

--- a/src/components/insights-space-detail-utilization-card/index.js
+++ b/src/components/insights-space-detail-utilization-card/index.js
@@ -79,8 +79,8 @@ export default class InsightsSpaceDetailUtilizationCard extends React.Component 
       data: null,
       dataSpaceId: null,
 
-      startDate: moment.utc().tz(this.props.space.timeZone).subtract(7, 'days').startOf('day').format(),
-      endDate: moment.utc().tz(this.props.space.timeZone).subtract(1, 'day').endOf('day').format(),
+      startDate: moment.utc().tz(props.space.timeZone).subtract(1, 'week').startOf('week').format(),
+      endDate: moment.utc().tz(props.space.timeZone).subtract(1, 'week').endOf('week').endOf('day').format(),
       timeSegment: 'WORKING_HOURS',
 
       includeWeekends: false,
@@ -192,8 +192,8 @@ export default class InsightsSpaceDetailUtilizationCard extends React.Component 
   // updates the state's `startDate` and `endDate` and triggers a `fetchData`
   setDatesAndFetchData(startDate, endDate) {
     this.setState({
-      startDate: startDate ? startDate.format() : undefined,
-      endDate: endDate ? endDate.endOf('day').format() : undefined,
+      startDate: startDate ? startDate.tz(this.props.space.timeZone).startOf('day').format() : undefined,
+      endDate: endDate ? endDate.tz(this.props.space.timeZone).endOf('day').format() : undefined,
     }, () => {
       // If the start date and end date were both set, then load data.
       if (this.state.startDate && this.state.endDate) {

--- a/src/components/insights-space-list/index.js
+++ b/src/components/insights-space-list/index.js
@@ -106,7 +106,7 @@ export class InsightsSpaceList extends React.Component {
 
       // NOTE: The below times don't have timezones. This is purposeful - the
       // `core.spaces.allCounts` call below can accept timezoneless timestamps, which in this case,
-      // is desired so that we can get from `startTime` to `endTime` in the timezone of each space,
+      // is desired so that we can get from `startDate` to `endDate` in the timezone of each space,
       // rather than in a fixed timezone between all spaces (since the list of spaces can be in
       // multiple timezones)
 
@@ -119,19 +119,20 @@ export class InsightsSpaceList extends React.Component {
       //  9  10
       //
       // ie, if the current date is the 10th, then the last full week goes from the 3rd to the 8th.
-      let startTime,
-          endTime = moment.utc().subtract(1, 'week').endOf('week').subtract(1, 'day').format('YYYY-MM-DDTHH:mm:ss');
+      let startDate,
+          endDate = moment.utc().subtract(1, 'week').endOf('week').endOf('day').format('YYYY-MM-DDTHH:mm:ss');
+
       if (this.state.dataDuration === DATA_DURATION_WEEK) {
-        startTime = moment.utc().subtract(1, 'week').startOf('week').subtract(1, 'day').startOf('day').format('YYYY-MM-DDTHH:mm:ss');
+        startDate = moment.utc().subtract(1, 'week').startOf('week').format('YYYY-MM-DDTHH:mm:ss');
       } else {
-        startTime = moment.utc().subtract(1, 'month').format('YYYY-MM-DDTHH:mm:ss');
+        startDate = moment.utc().subtract(1, 'month').format('YYYY-MM-DDTHH:mm:ss');
       }
 
       // Get all counts within that last full week. Request as many pages as required.
       const data = await fetchAllPages(page => {
         return core.spaces.allCounts({
-          start_time: startTime,
-          end_time: endTime,
+          start_time: startDate,
+          end_time: endDate,
           interval: '10m',
           page,
           page_size: 1000,
@@ -364,6 +365,7 @@ export class InsightsSpaceList extends React.Component {
                     {TIME_SEGMENTS[this.state.timeSegment].phrasal}
                   </CardWellHighlight> this past <CardWellHighlight>
                     {this.state.dataDuration === DATA_DURATION_WEEK ? 'week' : 'month'}
+                    {this.state.includeWeekends ? ', including weekends' : ''}
                   </CardWellHighlight>
                 </span>;
               } else {

--- a/src/components/nav-logged-in/index.js
+++ b/src/components/nav-logged-in/index.js
@@ -22,6 +22,10 @@ export default function NavLoggedIn({
       ]}
       href="#/onboarding/overview"
       onClick={closeSidebar}
+
+      // Lock the onboarding page in the demo account.
+      locked={user.data && user.data.isDemo}
+      lockedReason="Onboarding is unavailable in the demo account."
     >Onboarding</NavbarMobileItem>,
 
     <NavbarMobileItem
@@ -118,6 +122,10 @@ export default function NavLoggedIn({
         'ACCOUNT_SETUP_DOORWAY_DETAIL',
       ]}
       href="#/onboarding/overview"
+
+      // Lock the onboarding page in the demo account.
+      locked={user.data && user.data.isDemo}
+      lockedReason="Onboarding is unavailable in the demo account."
     >Onboarding</NavbarItem>
 
     <NavbarItem

--- a/src/reducers/user/index.js
+++ b/src/reducers/user/index.js
@@ -1,6 +1,7 @@
 import { USER_SET } from '../../actions/user/set';
 import { USER_PUSH } from '../../actions/user/push';
 import { USER_ERROR } from '../../actions/user/error';
+import { SESSION_TOKEN_UNSET } from '../../actions/session-token/unset';
 
 import objectSnakeToCamel from '../../helpers/object-snake-to-camel/index';
 import mixpanelUserReducerEnhancer from '../../helpers/mixpanel-user-reducer-enhancer/index';
@@ -19,6 +20,8 @@ export function user(state=initialState, action) {
     return {...state, loading: false, data: {...state.data, ...objectSnakeToCamel(action.item)}};
   case USER_ERROR:
     return {...state, loading: false, error: action.error};
+  case SESSION_TOKEN_UNSET:
+    return {...state, loading: false, data: null, error: null};
   default:
     return state;
   }


### PR DESCRIPTION
- Adjusted error handler - was previously redirecting to the login page when any 403 happened, now redirects when a response of `{"detail":"Incorrect authentication credentials"}` is received. Without this, anytime the demo user does anything they aren't supposed to, they get redirected to the login page.

- Disable the onboarding navbar item when the logged in user is a demo user.

<br/>

![screen shot 2018-07-02 at 8 37 35 am](https://user-images.githubusercontent.com/1704236/42164178-33433e7e-7dd3-11e8-83eb-8be6e2d36019.png)

- Remove the `Edit` and `Change Password` links on the account page when the logged in user is a demo user.