### PR TITLE
Remove extra error message in webhooks modal

### DIFF
--- a/src/components/dev-webhook-create/index.js
+++ b/src/components/dev-webhook-create/index.js
@@ -78,8 +78,6 @@ export default class WebhookCreateModal extends React.Component {
               }</pre>
             </div>
 
-            {this.props.error ? <span>Error: {this.props.error}</span> : null}
-
             <Button
               className="webhook-create-modal-submit"
               disabled={this.state.endpoint.length === 0}


### PR DESCRIPTION
Ben sent me a screenshot of the webhooks modal, it had some debugging text it looks like was never removed.