### PR TITLE
Error helper den 6542

### DIFF
--- a/src/actions/collection/doorways/fetch.js
+++ b/src/actions/collection/doorways/fetch.js
@@ -2,19 +2,26 @@ import collectionDoorwaysSet from './set';
 import collectionDoorwaysError from './error';
 import { core } from '../../../client';
 
+import errorHelper from '../../../helpers/error-helper/index';
+
 export const COLLECTION_DOORWAYS_FETCH = 'COLLECTION_DOORWAYS_FETCH';
 
 export default function collectionDoorwaysFetch() {
   return async dispatch => {
     dispatch({ type: COLLECTION_DOORWAYS_FETCH });
 
-    try {
-      const response = await core.doorways.list({environment: true});
-      dispatch(collectionDoorwaysSet(response.results));
-      return response;
-    } catch (err) {
-      dispatch(collectionDoorwaysError(err));
-      return false;
-    }
+    // Fetch a list of all doorways.
+    return errorHelper({
+      try: () => core.doorways.list({environment: true}),
+      catch: error => {
+        dispatch(collectionDoorwaysError(error));
+        return false;
+      },
+      else: async request => {
+        const doorways = await request;
+        dispatch(collectionDoorwaysSet(doorways.results));
+        return doorways;
+      },
+    });
   };
 }

--- a/src/actions/route-transition/dev-token-list.js
+++ b/src/actions/route-transition/dev-token-list.js
@@ -1,5 +1,7 @@
 import { accounts } from '../../client';
 import collectionTokensSet from '../collection/tokens/set';
+import collectionTokensError from '../collection/tokens/error';
+import errorHelper from '../../helpers/error-helper/index';
 
 export const ROUTE_TRANSITION_DEV_TOKEN_LIST = 'ROUTE_TRANSITION_DEV_TOKEN_LIST';
 
@@ -8,8 +10,15 @@ export default function routeTransitionDevTokenList() {
     dispatch({ type: ROUTE_TRANSITION_DEV_TOKEN_LIST });
 
     // Fetch a list of all tokens.
-    return accounts.tokens.list().then(tokens => {
-      dispatch(collectionTokensSet(tokens));
+    return errorHelper({
+      try: () => accounts.tokens.list(),
+      catch: error => {
+        dispatch(collectionTokensError(error));
+      },
+      else: async request => {
+        const tokens = await request;
+        dispatch(collectionTokensSet(tokens));
+      },
     });
   };
 }

--- a/src/actions/route-transition/dev-webhook-list.js
+++ b/src/actions/route-transition/dev-webhook-list.js
@@ -1,5 +1,7 @@
 import { core } from '../../client';
 import collectionWebhooksSet from '../collection/webhooks/set';
+import collectionWebhooksError from '../collection/webhooks/error';
+import errorHelper from '../../helpers/error-helper/index';
 
 export const ROUTE_TRANSITION_DEV_WEBHOOK_LIST = 'ROUTE_TRANSITION_DEV_WEBHOOK_LIST';
 
@@ -7,8 +9,15 @@ export default function routeTransitionDevWebhookList() {
   return dispatch => {
     dispatch({ type: ROUTE_TRANSITION_DEV_WEBHOOK_LIST });
 
-    return core.webhooks.list().then(webhooks => {
-      dispatch(collectionWebhooksSet(webhooks.results));
+    return errorHelper({
+      try: () => core.webhooks.list(),
+      catch: error => {
+        dispatch(collectionWebhooksError(error));
+      },
+      else: async request => {
+        const webhooks = await request;
+        dispatch(collectionWebhooksSet(webhooks.results));
+      },
     });
   };
 }

--- a/src/actions/route-transition/environment-space.js
+++ b/src/actions/route-transition/environment-space.js
@@ -1,26 +1,56 @@
 import { core } from '../../client';
 
 import collectionSpacesSet from '../collection/spaces/set';
+import collectionSpacesError from '../collection/spaces/error';
 import collectionDoorwaysSet from '../collection/doorways/set';
+import collectionDoorwaysError from '../collection/doorways/error';
 import collectionLinksSet from '../collection/links/set';
+import collectionLinksError from '../collection/links/error';
+
+import errorHelper from '../../helpers/error-helper/index';
 
 export const ROUTE_TRANSITION_ENVIRONMENT_SPACE = 'ROUTE_TRANSITION_ENVIRONMENT_SPACE';
 
 export default function routeTransitionEnvironment() {
-  return dispatch => {
+  return async dispatch => {
     dispatch({ type: ROUTE_TRANSITION_ENVIRONMENT_SPACE });
 
-    return Promise.all([
-      // Fetch a list of all spaces.
-      core.spaces.list(),
-      // Fetch a list of all doorways.
-      core.doorways.list({environment: true}),
-      // Fetch a list of all links.
-      core.links.list(),
-    ]).then(([spaces, doorways, links]) => {
-      dispatch(collectionSpacesSet(spaces.results));
-      dispatch(collectionDoorwaysSet(doorways.results));
-      dispatch(collectionLinksSet(links.results));
+    // Fetch a list of all spaces.
+    const spaces = errorHelper({
+      try: () => core.spaces.list(),
+      catch: error => {
+        dispatch(collectionSpacesError(`Error loading spaces: ${error}`));
+      },
+      else: async request => {
+        const spaces = await request;
+        dispatch(collectionSpacesSet(spaces.results));
+      },
     });
+
+    // Fetch a list of all doorways.
+    const doorways = errorHelper({
+      try: () => core.doorways.list({environment: true}),
+      catch: error => {
+        dispatch(collectionDoorwaysError(error));
+      },
+      else: async request => {
+        const doorways = await request;
+        dispatch(collectionDoorwaysSet(doorways.results));
+      },
+    });
+
+    // Fetch a list of all links.
+    const links = errorHelper({
+      try: () => core.links.list(),
+      catch: error => {
+        dispatch(collectionLinksError(error));
+      },
+      else: async request => {
+        const links = await request;
+        dispatch(collectionLinksSet(links.results));
+      },
+    });
+
+    return Promise.all([spaces, doorways, links]);
   };
 }

--- a/src/actions/route-transition/insights-space-data-export.js
+++ b/src/actions/route-transition/insights-space-data-export.js
@@ -1,8 +1,11 @@
 import { core } from '../../client';
 import collectionSpacesSet from '../collection/spaces/set';
 import collectionSpacesError from '../collection/spaces/error';
-
+import collectionTimeSegmentGroupsSet from '../collection/time-segment-groups/set';
+import collectionTimeSegmentGroupsError from '../collection/time-segment-groups/error';
 import collectionSpacesSetDefaultTimeRange from '../collection/spaces/set-default-time-range';
+
+import errorHelper from '../../helpers/error-helper/index';
 
 export const ROUTE_TRANSITION_INSIGHTS_SPACE_DATA_EXPORT = 'ROUTE_TRANSITION_INSIGHTS_SPACE_DATA_EXPORT';
 
@@ -10,13 +13,35 @@ export default function routeTransitionInsightsSpaceDataExport(id) {
   return async dispatch => {
     dispatch({ type: ROUTE_TRANSITION_INSIGHTS_SPACE_DATA_EXPORT, id });
 
-    try {
-      const spaces = await core.spaces.list();
-      const selectedSpace = spaces.results.find(s => s.id === id);
-      dispatch(collectionSpacesSet(spaces.results));
-      dispatch(collectionSpacesSetDefaultTimeRange(selectedSpace));
-    } catch (err) {
-      dispatch(collectionSpacesError(`Error loading spaces: ${err}`));
-    }
+    // Ideally, we'd load a single space (since the view only pertains to one space). But, we need
+    // every space to traverse through the space hierarchy and render a list of parent spaces on
+    // this view unrfortunately.
+    const spaces = errorHelper({
+      try: () => core.spaces.list(),
+      catch: err => {
+        dispatch(collectionSpacesError(`Error loading space: ${err.message}`));
+      },
+      else: async request => {
+        const spaces = await request;
+        const selectedSpace = spaces.results.find(s => s.id === id);
+        dispatch(collectionSpacesSetDefaultTimeRange(selectedSpace));
+        dispatch(collectionSpacesSet(spaces.results));
+      },
+    });
+
+    // Load a list of all time segment groups, which is required in order to render in the time
+    // segment list.
+    const timeSegmentGroups = errorHelper({
+      try: () => core.time_segment_groups.list(),
+      catch: err => {
+        dispatch(collectionTimeSegmentGroupsError(`Error loading time segments: ${err.message}`));
+      },
+      else: async request => {
+        const timeSegmentGroups = await request;
+        dispatch(collectionTimeSegmentGroupsSet(timeSegmentGroups.results));
+      },
+    });
+
+    return Promise.all([spaces, timeSegmentGroups]);
   }
 }

--- a/src/actions/route-transition/insights-space-list.js
+++ b/src/actions/route-transition/insights-space-list.js
@@ -5,6 +5,8 @@ import collectionSpacesError from '../collection/spaces/error';
 import collectionTimeSegmentGroupsSet from '../collection/time-segment-groups/set';
 import collectionTimeSegmentGroupsError from '../collection/time-segment-groups/error';
 
+import errorHelper from '../../helpers/error-helper/index';
+
 export const ROUTE_TRANSITION_INSIGHTS_SPACE_LIST = 'ROUTE_TRANSITION_INSIGHTS_SPACE_LIST';
 
 export default function routeTransitionInsightsSpaceList() {
@@ -12,20 +14,28 @@ export default function routeTransitionInsightsSpaceList() {
     dispatch({ type: ROUTE_TRANSITION_INSIGHTS_SPACE_LIST });
 
     // Load a list of all spaces
-    try {
-      const spaces = await core.spaces.list();
-      dispatch(collectionSpacesSet(spaces.results));
-    } catch (err) {
-      dispatch(collectionSpacesError(`Error loading space: ${err}`));
-    }
+    const spaces = errorHelper({
+      try: () => core.spaces.list(),
+      catch: error => {
+        dispatch(collectionSpacesError(`Error loading spaces: ${error}`));
+      },
+      else: async request => {
+        const spaces = await request;
+        dispatch(collectionSpacesSet(spaces.results));
+      },
+    });
 
-    // Load a list of all time segment groups, which is required in order to render in the time
-    // segment list.
-    try {
-      const timeSegmentGroups = await core.time_segment_groups.list();
-      dispatch(collectionTimeSegmentGroupsSet(timeSegmentGroups.results));
-    } catch (err) {
-      dispatch(collectionTimeSegmentGroupsError(`Error loading time segments: ${err}`));
-    }
+    const timeSegmentGroups = errorHelper({
+      try: () => core.time_segment_groups.list(),
+      catch: error => {
+        dispatch(collectionTimeSegmentGroupsError(`Error loading time segments: ${error}`));
+      },
+      else: async request => {
+        const timeSegmentGroups = await request;
+        dispatch(collectionTimeSegmentGroupsSet(timeSegmentGroups.results));
+      },
+    });
+
+    return Promise.all([spaces, timeSegmentGroups]);
   };
 }

--- a/src/actions/route-transition/insights-space-trends.js
+++ b/src/actions/route-transition/insights-space-trends.js
@@ -6,6 +6,8 @@ import collectionTimeSegmentGroupsSet from '../collection/time-segment-groups/se
 import collectionTimeSegmentGroupsError from '../collection/time-segment-groups/error';
 import collectionSpacesSetDefaultTimeRange from '../collection/spaces/set-default-time-range';
 
+import errorHelper from '../../helpers/error-helper/index';
+
 export const ROUTE_TRANSITION_INSIGHTS_SPACE_TRENDS = 'ROUTE_TRANSITION_INSIGHTS_SPACE_TRENDS';
 
 export default function routeTransitionInsightsSpaceTrends(id) {
@@ -15,22 +17,32 @@ export default function routeTransitionInsightsSpaceTrends(id) {
     // Ideally, we'd load a single space (since the view only pertains to one space). But, we need
     // every space to traverse through the space hierarchy and render a list of parent spaces on
     // this view unrfortunately.
-    try {
-      const spaces = await core.spaces.list();
-      const selectedSpace = spaces.results.find(s => s.id === id);
-      dispatch(collectionSpacesSetDefaultTimeRange(selectedSpace));
-      dispatch(collectionSpacesSet(spaces.results));
-    } catch (err) {
-      dispatch(collectionSpacesError(`Error loading space: ${err.message}`));
-    }
+    const spaces = errorHelper({
+      try: () => core.spaces.list(),
+      catch: err => {
+        dispatch(collectionSpacesError(`Error loading space: ${err.message}`));
+      },
+      else: async request => {
+        const spaces = await request;
+        const selectedSpace = spaces.results.find(s => s.id === id);
+        dispatch(collectionSpacesSetDefaultTimeRange(selectedSpace));
+        dispatch(collectionSpacesSet(spaces.results));
+      },
+    });
 
     // Load a list of all time segment groups, which is required in order to render in the time
     // segment list.
-    try {
-      const timeSegmentGroups = await core.time_segment_groups.list();
-      dispatch(collectionTimeSegmentGroupsSet(timeSegmentGroups.results));
-    } catch (err) {
-      dispatch(collectionTimeSegmentGroupsError(`Error loading time segments: ${err.message}`));
-    }
+    const timeSegmentGroups = errorHelper({
+      try: () => core.time_segment_groups.list(),
+      catch: err => {
+        dispatch(collectionTimeSegmentGroupsError(`Error loading time segments: ${err.message}`));
+      },
+      else: async request => {
+        const timeSegmentGroups = await request;
+        dispatch(collectionTimeSegmentGroupsSet(timeSegmentGroups.results));
+      },
+    });
+
+    return Promise.all([spaces, timeSegmentGroups]);
   }
 }

--- a/src/actions/route-transition/live-space-detail.js
+++ b/src/actions/route-transition/live-space-detail.js
@@ -5,6 +5,7 @@ import collectionSpacesPush from '../collection/spaces/push';
 import collectionSpacesError from '../collection/spaces/error';
 import collectionSpacesSetEvents from '../collection/spaces/set-events';
 import collectionSpacesSetDefaultTimeRange from '../collection/spaces/set-default-time-range';
+import errorHelper from '../../helpers/error-helper/index';
 
 import {
   getCurrentLocalTimeAtSpace,
@@ -17,25 +18,42 @@ export default function routeTransitionLiveSpaceDetail(id) {
   return async dispatch => {
     dispatch({ type: ROUTE_TRANSITION_LIVE_SPACE_DETAIL, id });
 
-    try {
-      const space = objectSnakeToCamel(await core.spaces.get({id}));
-      dispatch(collectionSpacesPush(space));
-      dispatch(collectionSpacesSetDefaultTimeRange(space));
+    const space = errorHelper({
+      try: async () => objectSnakeToCamel(await core.spaces.get({id})),
+      catch: err => {
+        dispatch(collectionSpacesError(`Error loading space live detail page: ${err}`));
+      },
+      else: async request => {
+        const space = await request;
+        dispatch(collectionSpacesPush(space));
+        dispatch(collectionSpacesSetDefaultTimeRange(space));
+      },
+    });
+    if (typeof space === 'undefined') { return; }
 
-      // Fetch all initial events for the space that was loaded.
-      // This is used to populate this space's events collection with all the events from the last
-      // minute so that the real time event charts all display as "full" when the page reloads.
-      const spaceEventSet = await core.spaces.events({
-        id: space.id,
-        start_time: formatInISOTime(getCurrentLocalTimeAtSpace(space).subtract(1, 'minute')),
-        end_time: formatInISOTime(getCurrentLocalTimeAtSpace(space)),
-      });
-      dispatch(collectionSpacesSetEvents(space, spaceEventSet.results.map(i => ({
-        countChange: i.direction,
-        timestamp: i.timestamp,
-      }))));
-    } catch (err) {
-      dispatch(collectionSpacesError(`Error loading space live detail page: ${err}`));
-    }
+    // Fetch all initial events for the space that was loaded.
+    // This is used to populate this space's events collection with all the events from the last
+    // minute so that the real time event charts all display as "full" when the page reloads.
+    const initialEvents = errorHelper({
+      try: () => {
+        return core.spaces.events({
+          id: space.id,
+          start_time: formatInISOTime(getCurrentLocalTimeAtSpace(space).subtract(1, 'minute')),
+          end_time: formatInISOTime(getCurrentLocalTimeAtSpace(space)),
+        });
+      },
+      catch: err => {
+        dispatch(collectionSpacesError(`Error loading space live detail page: ${err}`));
+      },
+      else: async request => {
+        const spaceEventSet = await request;
+        dispatch(collectionSpacesSetEvents(space, spaceEventSet.results.map(i => ({
+          countChange: i.direction,
+          timestamp: i.timestamp,
+        }))));
+      }
+    });
+
+    return Promise.all([space, initialEvents]);
   };
 }

--- a/src/helpers/error-helper/index.js
+++ b/src/helpers/error-helper/index.js
@@ -1,4 +1,4 @@
-export default function errorHelper(params /* {try, catch, finally, else} */) {
+export default async function errorHelper(params /* {try, catch, finally, else} */) {
   let result = undefined,
       errorThrown = false;
 
@@ -10,12 +10,20 @@ export default function errorHelper(params /* {try, catch, finally, else} */) {
     params.finally && params.finally();
   }
 
-  if (errorThrown) {
-    params.catch && params.catch(errorThrown);
+  if (errorThrown && params.catch) {
+    let catchResponse = params.catch(errorThrown);
+    if (catchResponse instanceof Promise) { catchResponse = await catchResponse; }
+    if (typeof catchResponse !== 'undefined') {
+      result = catchResponse;
+    }
   }
 
   if (!errorThrown && params.else) {
-    params.else(result);
+    const elseResponse = params.else(result);
+    if (elseResponse instanceof Promise) { await elseResponse; }
+    if (typeof elseResponse !== 'undefined') {
+      result = elseResponse;
+    }
   }
 
   return result;

--- a/src/helpers/error-helper/index.js
+++ b/src/helpers/error-helper/index.js
@@ -1,0 +1,22 @@
+export default function errorHelper(params /* {try, catch, finally, else} */) {
+  let result = undefined,
+      errorThrown = false;
+
+  try {
+    result = params.try();
+  } catch (error) {
+    errorThrown = error;
+  } finally {
+    params.finally && params.finally();
+  }
+
+  if (errorThrown) {
+    params.catch && params.catch(errorThrown);
+  }
+
+  if (!errorThrown && params.else) {
+    params.else(result);
+  }
+
+  return result;
+}

--- a/src/helpers/error-helper/test.js
+++ b/src/helpers/error-helper/test.js
@@ -2,17 +2,17 @@ import assert from 'assert';
 import errorHelper from './index';
 
 describe('error-helper', () => {
-  it('should by default return undefined if nothing is returned from try', () => {
+  it('should by default return undefined if nothing is returned from try', async () => {
     let caughtError = false;
-    const output = errorHelper({
+    const output = await errorHelper({
       try: () => { /* nothing */ },
     });
 
     assert.equal(output, undefined);
   });
-  it('should work with try+catch', () => {
+  it('should work with try+catch', async () => {
     let caughtError = false;
-    const output = errorHelper({
+    const output = await errorHelper({
       try: () => {
         throw new Error('SOS!');
       },
@@ -25,9 +25,9 @@ describe('error-helper', () => {
     assert(caughtError, 'Catch block was not run!');
     assert.equal(caughtError.message, 'SOS!');
   });
-  it('should work with try+else', () => {
+  it('should work with try+else', async () => {
     let elseHit = false;
-    const output = errorHelper({
+    const output = await errorHelper({
       try: () => {
         return 'Works!';
       },
@@ -39,9 +39,9 @@ describe('error-helper', () => {
     assert.equal(output, 'Works!');
     assert.equal(elseHit, true, 'Else branch was not hit');
   });
-  it('should work with try+catch+finally', () => {
+  it('should work with try+catch+finally', async () => {
     let caughtError = false, finallyHit = false;
-    const output = errorHelper({
+    const output = await errorHelper({
       try: () => {
         throw new Error('SOS!');
       },
@@ -58,9 +58,9 @@ describe('error-helper', () => {
     assert(caughtError, 'Catch block was not run!');
     assert.equal(caughtError.message, 'SOS!');
   });
-  it('should work with try+catch+else', () => {
+  it('should work with try+catch+else', async () => {
     let caughtError = false, elseHit = false;
-    const output = errorHelper({
+    const output = await errorHelper({
       try: () => {
         throw new Error('SOS!');
       },
@@ -76,6 +76,51 @@ describe('error-helper', () => {
     assert.equal(elseHit, false, 'Else block was run, even though an error was thrown!');
     assert(caughtError, 'Catch block was not run!');
     assert.equal(caughtError.message, 'SOS!');
+  });
+  it('should not swallow errors in the catch block', async () => {
+    let errorMessage = null;
+    try {
+      await errorHelper({
+        try: () => {
+          throw new Error('First!');
+        },
+        catch: error => {
+          throw new Error('Second!');
+        },
+        else: () => {
+          elseHit = true;
+        },
+      });
+    } catch (err) {
+      errorMessage = err.message;
+    }
+
+    assert.equal(errorMessage, 'Second!');
+  });
+  it('should return data that is returned from catch if an error is thrown in try', async () => {
+    const output = await errorHelper({
+      try: () => {
+        throw new Error('Throw an error!');
+        return 'IN TRY';
+      },
+      catch: error => {
+        return 'IN ERROR';
+      },
+    });
+
+    assert.equal(output, 'IN ERROR');
+  });
+  it('should return data that is returned from else', async () => {
+    const output = await errorHelper({
+      try: () => {
+        return 'IN TRY';
+      },
+      else: () => {
+        return 'IN ELSE';
+      },
+    });
+
+    assert.equal(output, 'IN ELSE');
   });
 });
 

--- a/src/helpers/error-helper/test.js
+++ b/src/helpers/error-helper/test.js
@@ -1,0 +1,81 @@
+import assert from 'assert';
+import errorHelper from './index';
+
+describe('error-helper', () => {
+  it('should by default return undefined if nothing is returned from try', () => {
+    let caughtError = false;
+    const output = errorHelper({
+      try: () => { /* nothing */ },
+    });
+
+    assert.equal(output, undefined);
+  });
+  it('should work with try+catch', () => {
+    let caughtError = false;
+    const output = errorHelper({
+      try: () => {
+        throw new Error('SOS!');
+      },
+      catch: error => {
+        caughtError = error;
+      },
+    });
+
+    assert.equal(output, undefined);
+    assert(caughtError, 'Catch block was not run!');
+    assert.equal(caughtError.message, 'SOS!');
+  });
+  it('should work with try+else', () => {
+    let elseHit = false;
+    const output = errorHelper({
+      try: () => {
+        return 'Works!';
+      },
+      else: () => {
+        elseHit = true;
+      },
+    });
+
+    assert.equal(output, 'Works!');
+    assert.equal(elseHit, true, 'Else branch was not hit');
+  });
+  it('should work with try+catch+finally', () => {
+    let caughtError = false, finallyHit = false;
+    const output = errorHelper({
+      try: () => {
+        throw new Error('SOS!');
+      },
+      catch: error => {
+        caughtError = error;
+      },
+      finally: () => {
+        finallyHit = true;
+      },
+    });
+
+    assert.equal(output, undefined);
+    assert.equal(finallyHit, true, 'Finally block was not run!');
+    assert(caughtError, 'Catch block was not run!');
+    assert.equal(caughtError.message, 'SOS!');
+  });
+  it('should work with try+catch+else', () => {
+    let caughtError = false, elseHit = false;
+    const output = errorHelper({
+      try: () => {
+        throw new Error('SOS!');
+      },
+      catch: error => {
+        caughtError = error;
+      },
+      else: () => {
+        elseHit = true;
+      },
+    });
+
+    assert.equal(output, undefined);
+    assert.equal(elseHit, false, 'Else block was run, even though an error was thrown!');
+    assert(caughtError, 'Catch block was not run!');
+    assert.equal(caughtError.message, 'SOS!');
+  });
+});
+


### PR DESCRIPTION
Many of the action creators in the dashboard contain code that looks like this:
```javascript
// Load a list of all spaces
try {
  const spaces = await core.spaces.list(); 
  dispatch(collectionSpacesSet(spaces.results));
} catch (err) {
  dispatch(collectionSpacesError(`Error loading space: ${err}`));
}
```

There's a pretty big bug with this though - the `dispatch` call is within the try block. Since the dispatch eventually ties into react through react-redux, any errors that are thrown in the component that are not handled in another way are not shown in the console and instead processed and stored into the reducer. This is not a good.

This is a work in progress PR to instead use a specially build "error helper" which contains an "else" branch that will fire when no error was thrown in the "try" branch, similarly to the way it works in python:
```javascript
return errorHelper({
  try: () => core.webhooks.list(),
  catch: error => {
    dispatch(collectionWebhooksError(error));
  },
  else: async request => {
    const webhooks = await request;
    dispatch(collectionWebhooksSet(webhooks.results));
  },
});
```
