### PR TITLE
DEN-6666-Collect-consent

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -68,6 +68,23 @@ core.doorways.update = function(data) {
   });
 };
 
+accounts.users.register = (data) => {
+  return fetch(`${accounts.config().host}/users/register/`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    body: JSON.stringify(data),
+  }).then(async response => {
+    if (response.ok) {
+      return response.json();
+    } else {
+      return Promise.reject(await errorHandler(response));
+    }
+  });
+};
+
 export {
   core,
   accounts,

--- a/src/client/specs/accounts-api.json
+++ b/src/client/specs/accounts-api.json
@@ -69,22 +69,6 @@
           "full_name": "{{full_name}}",
           "nickname": "{{nickname}}"
         }
-      },
-      "register": {
-        "method": "PUT",
-        "url": "{{{host}}}/users/register/",
-        "headers": {
-          "Content-Type": "application/json",
-          "Accept": "application/json"
-        },
-        "body": {
-          "email": "{{email}}",
-          "invitation_token": "{{invitation_token}}",
-          "password": "{{password}}",
-          "confirm_password": "{{password}}",
-          "full_name": "{{full_name}}",
-          "nickname": "{{nickname}}"
-        }
       }
     },
     "sensors": {

--- a/src/components/account-registration/_styles.scss
+++ b/src/components/account-registration/_styles.scss
@@ -50,3 +50,20 @@
   width: 100%;
   box-sizing: border-box;
 }
+
+.account-registration-consent-container {
+  display: flex;
+  align-content: center;
+  flex-direction: column;
+  margin: 12px 0;
+}
+
+.account-registration-consent {
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.account-registration-checkbox {
+  margin-right: 8px;
+}

--- a/src/components/account-registration/index.js
+++ b/src/components/account-registration/index.js
@@ -29,6 +29,8 @@ export class AccountRegistration extends React.Component {
       nickname: '',
       password: '',
       passwordConfirmation: '',
+      coreConsent: false,
+      marketingConsent: false,
     };
   }
   onSubmit() {
@@ -36,8 +38,11 @@ export class AccountRegistration extends React.Component {
       email: this.state.email,
       invitation_token: this.state.invitationToken,
       password: this.state.password,
+      confirm_password: this.state.password,
       full_name: this.state.fullName,
       nickname: this.state.nickname || this.generateNickname.apply(this),
+      core_consent: this.state.coreConsent,
+      marketing_consent: this.state.marketingConsent,
     }).then(response => {
       return this.props.onUserLoggedIn(response.session_token);
     }).catch(err => {
@@ -117,7 +122,28 @@ export class AccountRegistration extends React.Component {
               value={this.state.passwordConfirmation}
             />
 
-            <br />
+            <div className="account-registration-consent-container">
+              <div className="account-registration-consent">
+                <input
+                  type="checkbox"
+                  id="account-registration-core-consent"
+                  className="account-registration-checkbox"
+                  onChange={e => this.setState({coreConsent: e.target.checked})}
+                />
+                <label htmlFor="account-registration-core-consent">I confirm, by completing this registration, that I have read, understand, and agree to the Density <a href="https://www.density.io/Density-Terms-and-Conditions-1.0.0.pdf" target="_blank" rel="noopener noreferrer">Terms of Service</a>.</label>
+              </div>
+
+              <div className="account-registration-consent">
+                <input
+                  type="checkbox"
+                  id="account-registration-marketing-consent"
+                  className="account-registration-checkbox"
+                  onChange={e => this.setState({marketingConsent: e.target.checked})}
+                />
+                <label htmlFor='account-registration-marketing-consent'>I would like to sign up to receive marketing emails from Density. You can unsubscribe at any time.</label>
+              </div>
+            </div>
+
             <Button
               className="account-registration-submit-button"
               size="large"
@@ -127,7 +153,8 @@ export class AccountRegistration extends React.Component {
                 this.state.password === this.state.passwordConfirmation &&
                 this.state.fullName.length > 0 && 
                 (this.state.fullName.indexOf(' ') >= 0 || this.state.nickname.length > 0) &&
-                this.state.email.indexOf('@') >= 0
+                this.state.email.indexOf('@') >= 0 &&
+                this.state.coreConsent
               )}
             >Create Account</Button>
           </CardBody>

--- a/src/components/account-registration/index.js
+++ b/src/components/account-registration/index.js
@@ -140,7 +140,7 @@ export class AccountRegistration extends React.Component {
                   className="account-registration-checkbox"
                   onChange={e => this.setState({marketingConsent: e.target.checked})}
                 />
-                <label htmlFor='account-registration-marketing-consent'>I would like to sign up to receive marketing emails from Density. You can unsubscribe at any time.</label>
+                <label htmlFor="account-registration-marketing-consent">I would like to sign up to receive marketing emails from Density (unsubscribe is available at any time).</label>
               </div>
             </div>
 


### PR DESCRIPTION
# Description

Adds core and marketing consent collection to the invited user registration page. Submits those values to the registration API endpoint.

Closes DEN-6666

# Ready to Merge checklist

- [x] This branch is code-complete ( no outstanding TODOs )
- [x] I have tested this locally ( and it works )
- [x] All automated tests / linters pass
- [x] All dependencies, migrations, etc are committed

# UI

## Summary of UI changes

- Consent checkboxes added

![image](https://user-images.githubusercontent.com/5421124/49759019-7bf4da80-fc8e-11e8-9f0e-9a9c459ad34c.png)

# Notes / Known issues
'Core' consent, acknowledging that the user has access to and confirms reading the TOS, is now required to complete the registration. Marketing consent is optional.

![a1wgwxmmbj](https://user-images.githubusercontent.com/5421124/49759158-e4dc5280-fc8e-11e8-9471-e4f82c3f9630.gif)
