### PR TITLE
DEN-6668 edit consent

### DIFF
--- a/src/actions/user/update.js
+++ b/src/actions/user/update.js
@@ -3,18 +3,18 @@ import { USER_PUSH } from './push';
 
 export const USER_UPDATE = 'USER_UPDATE';
 
-export default function userUpdate(fullName, nickname, email) {
+export default function userUpdate(fullName, nickname, marketingConsent) {
   return (dispatch, getState) => {
-    dispatch({ type: USER_UPDATE, fullName, nickname, email });
+    dispatch({ type: USER_UPDATE, fullName, nickname, marketingConsent });
 
     // Set new user details.
     return accounts.users.update({
       full_name: fullName,
       nickname: nickname,
-      email,
+      marketing_consent: marketingConsent,
     }).then(() => {
       // Report success.
-      dispatch({ type: USER_PUSH, item: {fullName, nickname, email} });
+      dispatch({ type: USER_PUSH, item: {fullName, nickname, marketingConsent} });
     });
   };
 }

--- a/src/client/specs/accounts-api.json
+++ b/src/client/specs/accounts-api.json
@@ -65,7 +65,7 @@
           "Accept": "application/json"
         },
         "body": {
-          "email": "{{email}}",
+          "marketing_consent": "{{marketing_consent}}",
           "full_name": "{{full_name}}",
           "nickname": "{{nickname}}"
         }

--- a/src/components/account/_styles.scss
+++ b/src/components/account/_styles.scss
@@ -93,3 +93,24 @@
     left: calc(50% - 210px);
   }
 }
+
+.account-consent-container {
+  margin-bottom: 40px;
+}
+
+.account-consent {
+  display: flex;
+  align-items: center;
+  padding: 4px 0;
+}
+
+.account-checkbox {
+  margin-right: 8px;
+}
+
+.account-deactivate-container {
+  display: flex;
+  justify-content: center;
+  font-size: smaller;
+}
+

--- a/src/components/account/index.js
+++ b/src/components/account/index.js
@@ -156,6 +156,20 @@ export class Account extends React.Component {
             />}
           />
 
+          <div className="account-consent-container">
+            <div className="account-consent">
+              <input
+                type="checkbox"
+                id="account-marketing-consent"
+                className="account-checkbox"
+                onChange={e => this.setState({marketingConsent: e.target.checked})}
+                defaultChecked={user.data && user.data.marketingConsent}
+                disabled={this.state.mode !== EDIT}
+              />
+              <label htmlFor="account-marketing-consent">I want to receive marketing emails from Density.</label>
+            </div>
+            </div>
+
           {/* Trigger changing the password */}
           {this.state.mode === NORMAL && user.data && !user.data.isDemo ? <FormLabel
             className="account-change-password-link-container"
@@ -204,6 +218,10 @@ export class Account extends React.Component {
               }}
               disabled={this.state.password.length < 8}
             >Change Password</Button>
+          </div> : null}
+
+          {this.state.mode === NORMAL ? <div className="account-deactivate-container">
+              <span>If you&apos;d like to deactivate your account, please <a href="mailto:support@density.io?subject=I want to deactivate my Density account"> contact support</a>.</span>
           </div> : null}
 
           <div className="account-submit-user-details">

--- a/src/components/account/index.js
+++ b/src/components/account/index.js
@@ -34,6 +34,7 @@ export class Account extends React.Component {
       fullName: this.props.user.data ? this.props.user.data.fullName : '',
       nickname: this.props.user.data ? this.props.user.data.nickname : '',
       email: this.props.user.data ? this.props.user.data.email : '',
+      marketingConsent: this.props.user.data ? this.props.user.data.marketingConsent : false,
     };
   }
 
@@ -42,6 +43,7 @@ export class Account extends React.Component {
       fullName: nextProps.user.data.fullName || '',
       nickname: nextProps.user.data.nickname || '',
       email: nextProps.user.data.email || '',
+      marketingConsent: nextProps.user.data.marketingConsent,
     });
   }
 
@@ -227,7 +229,7 @@ export class Account extends React.Component {
           <div className="account-submit-user-details">
             {this.state.mode === EDIT ? <Button
               onClick={() => {
-                onSubmitUserUpdate(this.state.fullName, this.state.nickname, this.state.email)
+                onSubmitUserUpdate(this.state.fullName, this.state.nickname, this.state.marketingConsent)
                 .then(() => {
                   this.setState({mode: NORMAL});
                 }).catch(error => {
@@ -255,8 +257,8 @@ export default connect(state => {
         dispatch(showModal('account-password-reset'));
       });
     },
-    onSubmitUserUpdate(fullName, nickname, email) {
-      return dispatch(userUpdate(fullName, nickname, email));
+    onSubmitUserUpdate(fullName, nickname, marketingConsent) {
+      return dispatch(userUpdate(fullName, nickname, marketingConsent));
     },
     onHideSuccessToast() {
       dispatch(hideModal());

--- a/src/components/account/test.js
+++ b/src/components/account/test.js
@@ -16,6 +16,7 @@ const user = {
     organization: {
       name: 'baz',
     },
+    marketingConsent: true,
   },
 };
 
@@ -26,19 +27,21 @@ describe('Accounts page', function() {
       activeModal={{name: null}}
     />);
 
-    // Always show name and email inputs
-    assert.notEqual(component.find('.account-full-name-container').length, 0);
-    assert.notEqual(component.find('.account-nickname-container').length, 0);
-    assert.notEqual(component.find('.account-email-container').length, 0);
+    // Always show name, email, and consent inputs
+    assert.notStrictEqual(component.find('.account-full-name-container').length, 0);
+    assert.notStrictEqual(component.find('.account-nickname-container').length, 0);
+    assert.notStrictEqual(component.find('.account-email-container').length, 0);
+    assert.notStrictEqual(component.find('.account-deactivate-container').length, 0);
+    assert.notStrictEqual(component.find('.account-consent-container').length, 0);
 
     // Show change password link
-    assert.notEqual(component.find('.account-change-password-value').length, 0);
+    assert.notStrictEqual(component.find('.account-change-password-value').length, 0);
 
     // Don't show change password form
-    assert.equal(component.find('.account-change-password-form-container').length, 0);
+    assert.strictEqual(component.find('.account-change-password-form-container').length, 0);
 
     // Don't show submit user details button
-    assert.equal(component.find('.account-submit-user-details button').length, 0);
+    assert.strictEqual(component.find('.account-submit-user-details button').length, 0);
   });
   it('shows the password reset form after clicking the password reset link', function() {
     const component = mount(<Account
@@ -50,20 +53,21 @@ describe('Accounts page', function() {
     component.find('.account-change-password-value span').simulate('click');
 
     // Always show name and email inputs
-    assert.notEqual(component.find('.account-full-name-container').length, 0);
-    assert.notEqual(component.find('.account-nickname-container').length, 0);
-    assert.notEqual(component.find('.account-email-container').length, 0);
+    assert.notStrictEqual(component.find('.account-full-name-container').length, 0);
+    assert.notStrictEqual(component.find('.account-nickname-container').length, 0);
+    assert.notStrictEqual(component.find('.account-email-container').length, 0);
+    assert.notStrictEqual(component.find('.account-consent-container').length, 0);
 
     // Don't show change password link
-    assert.equal(component.find('.account-change-password-value span').length, 0);
+    assert.strictEqual(component.find('.account-change-password-value span').length, 0);
 
     // Show change password form
-    assert.notEqual(component.find('.account-change-password-form-container').length, 0);
+    assert.notStrictEqual(component.find('.account-change-password-form-container').length, 0);
 
     // Don't show submit user details button
-    assert.equal(component.find('.account-submit-user-details button').length, 0);
+    assert.strictEqual(component.find('.account-submit-user-details button').length, 0);
   });
-  it('makes the name / email editable when the user clicks the edit button', function() {
+  it('makes the name, email, and marketing consent editable when the user clicks the edit button', function() {
     const component = mount(<Account
       user={user}
       activeModal={{name: null}}
@@ -73,17 +77,22 @@ describe('Accounts page', function() {
     component.find('.account-edit-button').first().simulate('click');
 
     // Always show full-name and nickname inputs
-    assert.equal(component.find('.account-full-name-container input').prop('disabled'), false);
-    assert.equal(component.find('.account-nickname-container input').prop('disabled'), false);
+    assert.strictEqual(component.find('.account-full-name-container input').prop('disabled'), false);
+    assert.strictEqual(component.find('.account-nickname-container input').prop('disabled'), false);
+    assert.strictEqual(component.find('.account-full-name-container input').prop('disabled'), false);
+    assert.strictEqual(component.find('#account-marketing-consent').prop('disabled'), false);
 
     // Don't show change password link
-    assert.equal(component.find('.account-change-password-value span').length, 0);
+    assert.strictEqual(component.find('.account-change-password-value span').length, 0);
 
     // Don't show change password form
-    assert.equal(component.find('.account-change-password-form-container').length, 0);
+    assert.strictEqual(component.find('.account-change-password-form-container').length, 0);
+
+    // Don't show deactivate account blurb
+    assert.strictEqual(component.find('.account-deactivate-container').length, 0);
 
     // Show submit user details button
-    assert.notEqual(component.find('.account-submit-user-details button').length, 0);
+    assert.notStrictEqual(component.find('.account-submit-user-details button').length, 0);
   });
   it('resets the state of name back to original state when cancel is clicked', function() {
     const component = mount(<Account
@@ -95,8 +104,8 @@ describe('Accounts page', function() {
     component.find('.account-edit-button').first().simulate('click');
 
     // Ensure fullname and nickname inputs are visible
-    assert.equal(component.find('.account-full-name-container input').prop('disabled'), false);
-    assert.equal(component.find('.account-nickname-container input').prop('disabled'), false);
+    assert.strictEqual(component.find('.account-full-name-container input').prop('disabled'), false);
+    assert.strictEqual(component.find('.account-nickname-container input').prop('disabled'), false);
 
     // Change contents of nickname
     component.find('.account-nickname-container input').simulate('change', {
@@ -107,7 +116,7 @@ describe('Accounts page', function() {
     component.find('.account-edit-button').first().simulate('click');
 
     // Ensure that the original value is in the box
-    assert.equal(component.find('.account-nickname-container input').prop('value'), user.data.nickname);
+    assert.strictEqual(component.find('.account-nickname-container input').prop('value'), user.data.nickname);
   });
   it('sets the nickname to the best guess from the full name', function() {
     const component = mount(<Account
@@ -116,11 +125,11 @@ describe('Accounts page', function() {
     />);
 
     // Name defaults to 'Nickname'
-    assert.equal(component.find('.account-nickname-container input').prop('placeholder'), 'Nickname');
+    assert.strictEqual(component.find('.account-nickname-container input').prop('placeholder'), 'Nickname');
 
     // Nickname changes depending on full name
     component.setState({fullName: 'Foo Bar'});
-    assert.equal(component.find('.account-nickname-container input').prop('placeholder'), 'Foo');
+    assert.strictEqual(component.find('.account-nickname-container input').prop('placeholder'), 'Foo');
   });
   it('handles errors when changing password request fails', function() {
     const component = mount(<Account
@@ -132,8 +141,8 @@ describe('Accounts page', function() {
     component.find('.account-edit-button').first().simulate('click');
 
     // Ensure fullname and nickname inputs are visible
-    assert.equal(component.find('.account-full-name-container input').prop('disabled'), false);
-    assert.equal(component.find('.account-nickname-container input').prop('disabled'), false);
+    assert.strictEqual(component.find('.account-full-name-container input').prop('disabled'), false);
+    assert.strictEqual(component.find('.account-nickname-container input').prop('disabled'), false);
 
     // Change contents of nickname
     component.find('.account-nickname-container input').simulate('change', {
@@ -153,7 +162,7 @@ describe('Accounts page', function() {
     component.find('.account-edit-button').first().simulate('click');
 
     // Ensure that the error was reported
-    assert.equal(component.find('.error-bar').length, 1);
+    assert.strictEqual(component.find('.error-bar').length, 1);
   });
 
 
@@ -163,7 +172,7 @@ describe('Accounts page', function() {
     const component = mount(<Provider store={store}><ConnectedAccount /></Provider>);
 
     // Make sure a loading indicator is visible.
-    assert.equal(component.find('.card-loading').length, 1);
+    assert.strictEqual(component.find('.card-loading').length, 1);
   });
   it('shows a error bar when there is an error', function() {
     const component = mount(<Account
@@ -175,6 +184,6 @@ describe('Accounts page', function() {
     component.setState({error: 'boom!'});
 
     // Make sure an error bar is visible.
-    assert.equal(component.find('.error-bar').length, 1);
+    assert.strictEqual(component.find('.error-bar').length, 1);
   });
 });


### PR DESCRIPTION
# Description

Allows the user to edit their marketing consent and gives the user a link to click to contact support should they want to deactivate their account (i.e. revoke core consent).

Also removes `email` field from data submitted to user edit API endpoint.

Also updates account tests to replace deprecated test `equal` and `notEqual` calls to `strictEqual` and `notStrictEqual` respectively (`equal` and `notEqual` were deprecated in node v9.9.0).

Closes DEN-6668

# Ready to Merge checklist

- [x] This branch is code-complete ( no outstanding TODOs )
- [x] I have tested this locally ( and it works )
- [x] All automated tests / linters pass
- [x] All dependencies, migrations, etc are committed

# UI

## Summary of UI changes

- Fields added to account edit page

## GIF preview

![vsns4fitoy](https://user-images.githubusercontent.com/5421124/49899013-88ad3600-fe28-11e8-8371-7eb53deaf25c.gif)
