### PR TITLE
Add error boundary around each report

### DIFF
--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -159,20 +159,18 @@ function DashboardMainScrollViewContent({
                 {name !== null ? <h1 className="dashboard-header">{name}</h1> : null}
                 <div>
                   <DashboardReportGrid
-                    reports={[
-                      ...contents.map((report, index) => {
-                        return {
-                          id: `${report.id}-${dashboardReportGridIdentityValue}`,
-                          report: (
-                            <Report
-                              report={report}
-                              reportData={dashboards.calculatedReportData[report.id]}
-                              expanded={false}
-                            />
-                          ),
-                        };
-                      }),
-                    ]}
+                    reports={contents.map((report, index) => {
+                      return {
+                        id: `${report.id}-${dashboardReportGridIdentityValue}`,
+                        report: (
+                          <Report
+                            report={report}
+                            reportData={dashboards.calculatedReportData[report.id]}
+                            expanded={false}
+                          />
+                        ),
+                      };
+                    })}
                   />
                 </div>
               </div> : null}

--- a/src/reports.tsx
+++ b/src/reports.tsx
@@ -39,8 +39,8 @@ type ReportDefinition = {
 // Default report settings if no settings are defined in a report
 export const DEFAULT_REPORT_SETTINGS: ReportSettings = {
   isExpandable: false,
-  displayContextWhenExpanded: () => ({}),
-  displayContextWhenNotExpanded: () => ({}),
+  displayContextWhenExpanded: {},
+  displayContextWhenNotExpanded: {},
 };
 
 


### PR DESCRIPTION
If a report throws an error while rendering, then render a "report error" state instead of letting the error make its way to react and causing the whole app to unmount. This gets rid of the issue where a report failing to render would cause the whole application to unmount and a white screen shown instead.