### PR TITLE
Add sibling space selector to the locations breadcrumb

### DIFF
--- a/src/components/admin-locations-breadcrumb/index.tsx
+++ b/src/components/admin-locations-breadcrumb/index.tsx
@@ -1,9 +1,14 @@
-import React, { Fragment } from 'react';
+import React, { Component, Fragment } from 'react';
+import classnames from 'classnames';
 import styles from './styles.module.scss';
 
-import { Icons } from '@density/ui';
+import { DensitySpace } from '../../types';
 
-export default function AdminLocationsBreadcrumb({ space }) {
+import { InputBox, Icons } from '@density/ui';
+
+import filterCollection from '../../helpers/filter-collection/index';
+
+export default function AdminLocationsBreadcrumb({ spaces, space }) {
   if (space) {
     return (
       <div className={styles.breadcrumb}>
@@ -24,8 +29,10 @@ export default function AdminLocationsBreadcrumb({ space }) {
         })}
 
         <span className={styles.item}>
-          <span className={styles.finalText}>{space.name}</span>
-          <Icons.ChevronDown width={12} height={12} />
+          <BreadcrumbSiblingSelector selectedSpace={space} spaces={spaces}>
+            <span className={styles.finalText}>{space.name}</span>
+            <Icons.ChevronDown width={12} height={12} />
+          </BreadcrumbSiblingSelector>
         </span>
       </div>
     );
@@ -34,6 +41,117 @@ export default function AdminLocationsBreadcrumb({ space }) {
       <div className={styles.breadcrumb}>
         <a href="#/admin/locations" className={styles.item}>Locations</a>
       </div>
+    );
+  }
+}
+
+type BreadcrumbSiblingSelectorProps = {
+  children: React.ReactNode,
+  spaces: {
+    view: 'VISIBLE' | 'ERROR' | 'LOADING',
+    data: Array<DensitySpace>,
+    error: any,
+  },
+  selectedSpace: DensitySpace,
+};
+
+type BreadcrumbSiblingSelectorState = {
+  visible: boolean,
+  activeItemIndex: number | null,
+  filterText: string,
+};
+
+const nameFilter = filterCollection({fields: ['name']});
+
+export class BreadcrumbSiblingSelector extends Component<BreadcrumbSiblingSelectorProps, BreadcrumbSiblingSelectorState> {
+  state = {
+    visible: false,
+    activeItemIndex: null,
+    filterText: '',
+  }
+
+  onShow = () => {
+    this.setState({visible: true, activeItemIndex: null, filterText: ''});
+  }
+  onHide = () => {
+    this.setState({visible: false});
+  }
+
+  render() {
+    const { filterText, activeItemIndex, visible } = this.state;
+    const { selectedSpace, spaces, children } = this.props;
+
+    const rawItems = spaces.data.filter(s => s.parentId === selectedSpace.parentId);
+    const items = nameFilter(rawItems, filterText);
+
+    return (
+      <Fragment>
+        <div
+          className={styles.backdrop}
+          style={{display: visible ? 'block' : 'none'}}
+          onClick={() => this.onHide()}
+        />
+        <div className={styles.wrapper}>
+          <span className={styles.target} onClick={() => this.onShow()}>{children}</span>
+          <div className={styles.popup} style={{opacity: visible ? 1 : 0}}>
+            <InputBox
+              width="auto"
+              type="text"
+              placeholder="Search by space name"
+              value={filterText}
+              onChange={e => this.setState({
+                filterText: e.target.value,
+                activeItemIndex: null,
+              })}
+              onKeyDown={e => {
+                if (e.key === 'ArrowDown') {
+                  if (activeItemIndex === null) {
+                    this.setState({activeItemIndex: 0});
+                  } else if (
+                    typeof activeItemIndex === 'number' &&
+                    (activeItemIndex as any) < items.length-1
+                  ) {
+                    this.setState({activeItemIndex: (activeItemIndex as any) + 1});
+                  }
+
+                } else if (e.key === 'ArrowUp') {
+                  if (activeItemIndex === null) {
+                    this.setState({activeItemIndex: 0});
+                  } else if (
+                    typeof activeItemIndex === 'number' &&
+                    (activeItemIndex as any) > 0
+                  ) {
+                    this.setState({activeItemIndex: (activeItemIndex as any) - 1});
+                  }
+
+                } else if (e.key === 'Enter' && activeItemIndex !== null) {
+                  this.onHide();
+                  window.location.href = `#/admin/locations/${items[activeItemIndex as any].id}`;
+                } else if (e.key === 'Escape') {
+                  this.onHide();
+                }
+              }}
+            />
+            <nav onMouseLeave={() => this.setState({activeItemIndex: null})}>
+              {items.map((space, index) => (
+                <div
+                  key={space.id}
+                  className={classnames(
+                    styles.popupItem,
+                    {[styles.active]: activeItemIndex === index}
+                  )}
+                  onMouseEnter={() => this.setState({activeItemIndex: index})}
+                >
+                  <a
+                    href={`#/admin/locations/${space.id}`}
+                    onClick={this.onHide}
+                  >{space.name}</a>
+                </div>
+              ))}
+            </nav>
+          </div>
+        </div>
+      </Fragment>
     );
   }
 }

--- a/src/components/admin-locations-breadcrumb/styles.module.scss
+++ b/src/components/admin-locations-breadcrumb/styles.module.scss
@@ -1,4 +1,5 @@
 @import "@density/ui/variables/colors.scss";
+@import "@density/ui/variables/spacing.scss";
 
 .breadcrumb {
   display: flex;
@@ -13,6 +14,8 @@
   font-weight: 500;
   color: $grayDarker;
   text-decoration: none;
+  user-select: none;
+  white-space: nowrap;
 }
 .item:first-child { margin-left: 0px; }
 .item:last-child {
@@ -22,4 +25,59 @@
 
 .finalText {
   margin-right: 8px;
+}
+
+
+
+.backdrop {
+  position: fixed;
+  top: 0px;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
+  background-color: transparent;
+}
+.wrapper { position: relative; }
+.target { cursor: pointer; }
+.popup {
+  position: absolute;
+  top: 36px;
+
+  display: flex;
+  flex-direction: column;
+
+  padding: 16px;
+  font-size: 16px;
+  font-weight: normal;
+  background-color: #fff;
+  border: 1px solid $grayLight;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.1);
+
+  transition: all 100ms ease-in-out;
+  width: 348px;
+}
+.popup nav {
+  margin-top: 16px;
+  height: 100%;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.popupItem {
+  line-height: 36px;
+  padding-left: 8px;
+  padding-right: 8px;
+  border-radius: $borderRadiusSmall;
+}
+.popupItem a {
+  text-decoration: none;
+  font-weight: bold;
+  font-size: 16px;
+  color: $grayCinder;
+  display: inline-block;
+  width: 100%;
+}
+.popupItem.active { background-color: $grayLighter; }
+.popupItem.active a {
+  color: $brandPrimary;
+  text-decoration: underline;
 }

--- a/src/components/admin-locations/index.tsx
+++ b/src/components/admin-locations/index.tsx
@@ -2,6 +2,7 @@ import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import styles from './styles.module.scss';
 import Skeleton from '../skeleton/index';
+import GenericErrorState from '../generic-error-state/index';
 import colorVariables from '@density/ui/variables/colors.json';
 
 import { DensitySpace } from '../../types';
@@ -79,12 +80,16 @@ function AdminLocations({selectedSpace, spaces}) {
         </div>
       ) : null}
 
+      {spaces.view === 'ERROR' ? (
+        <GenericErrorState />
+      ) : null}
+
       {spaces.view === 'VISIBLE' ? (
         <Fragment>
           <div className={styles.appBar}>
             <AppBar>
               <AppBarSection>
-                <Breadcrumb space={selectedSpace} />
+                <Breadcrumb space={selectedSpace} spaces={spaces} />
               </AppBarSection>
               <AppBarSection>
                 <ActionButtons spaceType={selectedSpace ? selectedSpace.spaceType : null} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export type DensitySpace = {
   id: string,
   name: string,
   description: string,
-  parentid: string,
+  parentId: string,
   spaceType: DensitySpaceTypes,
   timeZone: string,
   dailyReset: string,


### PR DESCRIPTION
Add breadcrumb space selector, which uses the list of loaded spaces to display all siblings and allow navigation to them.

Rough example:
![http://g.recordit.co/vk8TSNHU7v.gif](http://g.recordit.co/vk8TSNHU7v.gif)