### PR TITLE
(try to) fix two bugs in relation to the date picker

### DIFF
--- a/src/actions/route-transition/explore-space-trends.ts
+++ b/src/actions/route-transition/explore-space-trends.ts
@@ -350,7 +350,14 @@ export function calculateHourlyBreakdown(space, reportName, metric, title, aggre
   return async (dispatch, getState) => {
     dispatch(exploreDataCalculateDataLoading(reportName, null));
     const { startDate, endDate } = getState().spaces.filters;
-    const report = generateHourlyBreakdownEphemeralReport(space, startDate, endDate, metric, title, aggregation);
+    const report = generateHourlyBreakdownEphemeralReport(
+      space,
+      formatInISOTimeAtSpace(moment.utc(startDate), space),
+      formatInISOTimeAtSpace(moment.utc(endDate), space),
+      metric,
+      title,
+      aggregation,
+    );
 
     let data, errorThrown: any = false;
     try {

--- a/src/components/explore-space-data-export/index.tsx
+++ b/src/components/explore-space-data-export/index.tsx
@@ -20,6 +20,10 @@ import collectionSpacesFilter from '../../actions/collection/spaces/filter';
 
 import getCommonRangesForSpace from '../../helpers/common-ranges';
 
+import isOutsideRange, {
+  MAXIMUM_DAY_LENGTH,
+} from '../../helpers/date-range-picker-is-outside-range/index';
+
 import {
   parseISOTimeAtSpace,
   parseFromReactDates,
@@ -27,30 +31,9 @@ import {
   formatForReactDates,
 } from '../../helpers/space-time-utilities/index';
 
-// The maximum number of days that can be selected by the date range picker
-const MAXIMUM_DAY_LENGTH = 3 * 31; // Three months of data
-
 // When the user selects a start date, select a range that's this long. THe user can stil ladjust
 // the range up to a maximum length of `MAXIMUM_DAY_LENGTH` though.
 const INITIAL_RANGE_SELECTION = MAXIMUM_DAY_LENGTH / 2;
-
-// Given a day on the calendar and the current day, determine if the square on the calendar should
-// be grayed out or not.
-export function isOutsideRange(startISOTime, datePickerInput, day) {
-  const startDate = moment.utc(startISOTime);
-  if (day.isAfter(moment.utc())) {
-    return true;
-  }
-
-  if (datePickerInput === 'endDate') {
-    return datePickerInput === 'endDate' && startDate &&
-      !( // Is the given `day` within `MAXIMUM_DAY_LENGTH` days from the start date?
-        isInclusivelyAfterDay(day, startDate) &&
-        isInclusivelyBeforeDay(day, startDate.clone().add(MAXIMUM_DAY_LENGTH - 1, 'days'))
-      );
-  }
-  return false;
-}
 
 function ExploreSpaceDataExport({
   spaces,
@@ -94,11 +77,7 @@ function ExploreSpaceDataExport({
               // On desktop, the calendar is two months wide and right aligned.
               numberOfMonths={document.body && document.body.clientWidth > gridVariables.screenSmMin ? 2 : 1}
 
-              isOutsideRange={day => isOutsideRange(
-                spaces.filters.startDate,
-                spaces.filters.datePickerInput,
-                day
-              )}
+              isOutsideRange={isOutsideRange}
 
               // common ranges functionality
               commonRanges={getCommonRangesForSpace(space)}

--- a/src/components/explore-space-data-export/index.tsx
+++ b/src/components/explore-space-data-export/index.tsx
@@ -77,7 +77,7 @@ function ExploreSpaceDataExport({
               // On desktop, the calendar is two months wide and right aligned.
               numberOfMonths={document.body && document.body.clientWidth > gridVariables.screenSmMin ? 2 : 1}
 
-              isOutsideRange={isOutsideRange}
+              isOutsideRange={day => isOutsideRange(space, day)}
 
               // common ranges functionality
               commonRanges={getCommonRangesForSpace(space)}

--- a/src/components/explore-space-detail-daily-metrics-card/index.tsx
+++ b/src/components/explore-space-detail-daily-metrics-card/index.tsx
@@ -43,32 +43,11 @@ const ONE_MINUTE_IN_MS = 60 * 1000,
       ONE_HOUR_IN_MS = ONE_MINUTE_IN_MS * 60,
       ONE_DAY_IN_MS = ONE_HOUR_IN_MS * 60;
 
-// The maximum number of days that can be selected by the date range picker
-const MAXIMUM_DAY_LENGTH = 3 * 31; // Three months of data
-
 // Below this number of days or equal to this number of days, show the normal daily metrics chart.
 // Above this number of days, show the expanded line chart.
 const GRAPH_TYPE_TRANSITION_POINT_IN_DAYS = 14;
 
 const CHART_HEIGHT = 350;
-
-// Given a day on the calendar and the current day, determine if the square on the calendar should
-// be grayed out or not.
-export function isOutsideRange(startISOTime, datePickerInput, day) {
-  const startDate = moment.utc(startISOTime);
-  if (day.isAfter(moment.utc())) {
-    return true;
-  }
-
-  if (datePickerInput === 'endDate') {
-    return datePickerInput === 'endDate' && startDate &&
-      !( // Is the given `day` within `MAXIMUM_DAY_LENGTH` days from the start date?
-        isInclusivelyAfterDay(day, startDate) &&
-        isInclusivelyBeforeDay(day, startDate.clone().add(MAXIMUM_DAY_LENGTH - 1, 'days'))
-      );
-  }
-  return false;
-}
 
 export class ExploreSpaceDetailDailyMetricsCard extends Component<any, any> {
   render() {

--- a/src/components/explore-space-meetings/index.tsx
+++ b/src/components/explore-space-meetings/index.tsx
@@ -39,30 +39,13 @@ import collectionSpacesFilter from '../../actions/collection/spaces/filter';
 import getCommonRangesForSpace from '../../helpers/common-ranges';
 import { DensitySpaceMapping, DensityRobinSpace, DensityTeemSpace } from '../../types';
 
-// The maximum number of days that can be selected by the date range picker
-const MAXIMUM_DAY_LENGTH = 3 * 31; // Three months of data
+import isOutsideRange, {
+  MAXIMUM_DAY_LENGTH,
+} from '../../helpers/date-range-picker-is-outside-range/index';
 
 // When the user selects a start date, select a range that's this long. THe user can stil ladjust
 // the range up to a maximum length of `MAXIMUM_DAY_LENGTH` though.
 const INITIAL_RANGE_SELECTION = MAXIMUM_DAY_LENGTH / 2;
-
-// Given a day on the calendar and the current day, determine if the square on the calendar should
-// be grayed out or not.
-export function isOutsideRange(startISOTime, datePickerInput, day) {
-  const startDate = moment.utc(startISOTime);
-  if (day.isAfter(moment.utc())) {
-    return true;
-  }
-
-  if (datePickerInput === 'endDate') {
-    return datePickerInput === 'endDate' && startDate &&
-      !( // Is the given `day` within `MAXIMUM_DAY_LENGTH` days from the start date?
-        isInclusivelyAfterDay(day, startDate) &&
-        isInclusivelyBeforeDay(day, startDate.clone().add(MAXIMUM_DAY_LENGTH - 1, 'days'))
-      );
-  }
-  return false;
-}
 
 function flattenRobinSpaces(robinSpaces) {
   if (!robinSpaces) {
@@ -141,11 +124,7 @@ function ExploreSpaceMeetings({
                     // On desktop, the calendar is two months wide and right aligned.
                     numberOfMonths={document.body && document.body.clientWidth > gridVariables.screenSmMin ? 2 : 1}
 
-                    isOutsideRange={day => isOutsideRange(
-                      spaces.filters.startDate,
-                      spaces.filters.datePickerInput,
-                      day
-                    )}
+                    isOutsideRange={isOutsideRange}
 
                     // common ranges functionality
                     commonRanges={getCommonRangesForSpace(space)}

--- a/src/components/explore-space-trends/index.tsx
+++ b/src/components/explore-space-trends/index.tsx
@@ -182,7 +182,7 @@ class ExploreSpaceTrends extends React.Component<any, any> {
                 // On desktop, the calendar is two months wide and right aligned.
                 numberOfMonths={document.body && document.body.clientWidth > gridVariables.screenSmMin ? 2 : 1}
 
-                isOutsideRange={isOutsideRange}
+                isOutsideRange={day => isOutsideRange(space, day)}
 
                 // common ranges functionality
                 commonRanges={getCommonRangesForSpace(space)}

--- a/src/helpers/date-range-picker-is-outside-range/index.js
+++ b/src/helpers/date-range-picker-is-outside-range/index.js
@@ -9,7 +9,7 @@ export default function isOutsideRange(space, localDay) {
   const day = parseISOTimeAtSpace(localDay, space);
   const now = getCurrentLocalTimeAtSpace(space);
 
-  // If a startDate is selected, then permit the next MAXIMUM_DAY_LENGTH days to be selectable
+  // If a startDate is selected, then permit the previous MAXIMUM_DAY_LENGTH days to be selectable
   const rangeStart = now.clone().subtract(MAXIMUM_DAY_LENGTH-1, 'days');
   const rangeEnd = now.clone().subtract(1, 'day');
   const isWithinRange = (

--- a/src/helpers/date-range-picker-is-outside-range/index.js
+++ b/src/helpers/date-range-picker-is-outside-range/index.js
@@ -1,13 +1,13 @@
-import moment from 'moment';
+import { getCurrentLocalTimeAtSpace, parseISOTimeAtSpace } from '../space-time-utilities/index';
 
 // The maximum number of days in the past that can be selected by the date range picker
 export const MAXIMUM_DAY_LENGTH = 3 * 31; // Three months of data
 
 // Given a day on the calendar and the current day, determine if the square on the calendar should
 // be grayed out or not.
-export default function isOutsideRange(localDay) {
-  const day = moment.utc(localDay);
-  const now = moment.utc();
+export default function isOutsideRange(space, localDay) {
+  const day = parseISOTimeAtSpace(localDay, space);
+  const now = getCurrentLocalTimeAtSpace(space);
 
   // If a startDate is selected, then permit the next MAXIMUM_DAY_LENGTH days to be selectable
   const rangeStart = now.clone().subtract(MAXIMUM_DAY_LENGTH-1, 'days');

--- a/src/helpers/date-range-picker-is-outside-range/index.js
+++ b/src/helpers/date-range-picker-is-outside-range/index.js
@@ -1,0 +1,19 @@
+import moment from 'moment';
+
+// The maximum number of days in the past that can be selected by the date range picker
+export const MAXIMUM_DAY_LENGTH = 3 * 31; // Three months of data
+
+// Given a day on the calendar and the current day, determine if the square on the calendar should
+// be grayed out or not.
+export default function isOutsideRange(localDay) {
+  const day = moment.utc(localDay);
+  const now = moment.utc();
+
+  // If a startDate is selected, then permit the next MAXIMUM_DAY_LENGTH days to be selectable
+  const rangeStart = now.clone().subtract(MAXIMUM_DAY_LENGTH-1, 'days');
+  const rangeEnd = now.clone().subtract(1, 'day');
+  const isWithinRange = (
+    day.isAfter(rangeStart, 'day') && day.isSameOrBefore(rangeEnd, 'day')
+  );
+  return !isWithinRange;
+}


### PR DESCRIPTION
- The hourly breakdown report was missing a day when a date range was
selected.
- Changed how the days are grayed out to make a bit more sense maybe

This needs some testing, I'm not sure if this actually solves the problem fully.

DEN-7895