### PR TITLE
Fix meetings date picker issue

### DIFF
--- a/src/components/explore-space-meetings/index.tsx
+++ b/src/components/explore-space-meetings/index.tsx
@@ -124,7 +124,7 @@ function ExploreSpaceMeetings({
                     // On desktop, the calendar is two months wide and right aligned.
                     numberOfMonths={document.body && document.body.clientWidth > gridVariables.screenSmMin ? 2 : 1}
 
-                    isOutsideRange={isOutsideRange}
+                    isOutsideRange={day => isOutsideRange(space, day)}
 
                     // common ranges functionality
                     commonRanges={getCommonRangesForSpace(space)}

--- a/src/helpers/date-range-picker-is-outside-range/index.js
+++ b/src/helpers/date-range-picker-is-outside-range/index.js
@@ -19,8 +19,8 @@ export default function isOutsideRange(space, localDay) {
   // timezone bug in the date picker, look here first.
   //
   // Sorry in advance :(
-  const day = localDay.clone().zone(space.timeZone).startOf('day');
-  //                           ^- That .zone method overrides the time zone on the moment (doesn't
+  const day = localDay.clone().utcOffset(space.timeZone).startOf('day');
+  //                           ^- That .utcOffset method overrides the time zone on the moment (doesn't
   //                           effect the date and time part of the moment), which is different from
   //                           .tz, which adjusts the moment into a time zone and the date and time
   //                           to a new locale.


### PR DESCRIPTION
There was a typo in the meetings date picker's invocation of `isOutsideRange` it looks like, oops

DEN-7906