### PR TITLE
Navbar dropdown reordering

### DIFF
--- a/src/components/admin-locations-building-detail/index.tsx
+++ b/src/components/admin-locations-building-detail/index.tsx
@@ -104,9 +104,11 @@ export default function AdminLocationsBuildingDetail({ user, spaces, selectedSpa
         <AppBar>
           <AppBarTitle>{selectedSpace.name}</AppBarTitle>
           <AppBarSection>
-            <Button onClick={() => {
-              window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
-            }}>Edit</Button>
+            {user.data.permissions.includes('core_write') ? (
+              <Button onClick={() => {
+                window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
+              }}>Edit</Button>
+            ) : null}
           </AppBarSection>
         </AppBar>
         {mapShown ? (

--- a/src/components/admin-locations-campus-detail/index.tsx
+++ b/src/components/admin-locations-campus-detail/index.tsx
@@ -40,9 +40,11 @@ export default function AdminLocationsCampusDetail({ user, spaces, selectedSpace
         <AppBar>
           <AppBarTitle>{selectedSpace.name}</AppBarTitle>
           <AppBarSection>
-            <Button onClick={() => {
-              window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
-            }}>Edit</Button>
+            {user.data.permissions.includes('core_write') ? (
+              <Button onClick={() => {
+                window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
+              }}>Edit</Button>
+            ) : null}
           </AppBarSection>
         </AppBar>
         {mapShown ? (

--- a/src/components/admin-locations-floor-detail/index.tsx
+++ b/src/components/admin-locations-floor-detail/index.tsx
@@ -37,9 +37,11 @@ export default function AdminLocationsFloorDetail({ user, spaces, selectedSpace 
         <AppBar>
           <AppBarTitle>{selectedSpace.name}</AppBarTitle>
           <AppBarSection>
-            <Button onClick={() => {
-              window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
-            }}>Edit</Button>
+            {user.data.permissions.includes('core_write') ? (
+              <Button onClick={() => {
+                window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
+              }}>Edit</Button>
+            ) : null}
           </AppBarSection>
         </AppBar>
         <AdminLocationsLeftPaneDataRow includeTopBorder={false}>

--- a/src/components/admin-locations-space-detail/index.tsx
+++ b/src/components/admin-locations-space-detail/index.tsx
@@ -77,9 +77,11 @@ export default function AdminLocationsSpaceDetail({ user, spaces, selectedSpace 
           <AppBar>
             <AppBarTitle>{selectedSpace.name}</AppBarTitle>
             <AppBarSection>
-              <Button onClick={() => {
-                window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
-              }}>Edit</Button>
+              {user.data.permissions.includes('core_write') ? (
+                <Button onClick={() => {
+                  window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
+                }}>Edit</Button>
+              ) : null}
             </AppBarSection>
           </AppBar>
           <AdminLocationsLeftPaneDataRow includeTopBorder={false}>
@@ -96,9 +98,11 @@ export default function AdminLocationsSpaceDetail({ user, spaces, selectedSpace 
           <AppBar>
             <AppBarTitle>{selectedSpace.name}</AppBarTitle>
             <AppBarSection>
-              <Button onClick={() => {
-                window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
-              }}>Edit</Button>
+              {user.data.permissions.includes('core_write') ? (
+                <Button onClick={() => {
+                  window.location.href = `#/admin/locations/${selectedSpace.id}/edit`;
+                }}>Edit</Button>
+              ) : null}
             </AppBarSection>
           </AppBar>
           <AdminLocationsLeftPaneDataRow includeTopBorder={false}>

--- a/src/components/admin-locations/index.tsx
+++ b/src/components/admin-locations/index.tsx
@@ -188,7 +188,9 @@ function AdminLocations({user, selectedSpace, spaces}) {
                   <Skeleton width={200} height={8} />
                 </AppBarSection>
                 <AppBarSection>
-                  <Button>Edit</Button>
+                  {user.data.permissions.includes('core_write') ? (
+                    <Button>Edit</Button>
+                  ) : null}
                 </AppBarSection>
               </AppBar>
               <div className={styles.loadingMapSkeleton} />
@@ -272,11 +274,13 @@ function AdminLocations({user, selectedSpace, spaces}) {
                 <Breadcrumb space={selectedSpace} spaces={spaces} />
               </AppBarSection>
               <AppBarSection>
-                <ActionButtons
-                  spaceId={selectedSpace ? selectedSpace.id : null}
-                  spaceType={selectedSpace ? selectedSpace.spaceType : null}
-                  parentSpaceType={selectedSpaceParentSpaceType}
-                />
+                {user.data.permissions.includes('core_write') ? (
+                  <ActionButtons
+                    spaceId={selectedSpace ? selectedSpace.id : null}
+                    spaceType={selectedSpace ? selectedSpace.spaceType : null}
+                    parentSpaceType={selectedSpaceParentSpaceType}
+                  />
+                ) : null}
               </AppBarSection>
             </AppBar>
           </div>

--- a/src/components/app-navbar/index.tsx
+++ b/src/components/app-navbar/index.tsx
@@ -231,6 +231,12 @@ export default function AppNavbar({
               />}
             >
               <AppNavbarMenuItem
+                path="#/admin/locations"
+                text="Locations"
+                icon={<Icons.Globe />}
+                selected={['ADMIN_LOCATIONS'].includes(page)}
+              />
+              <AppNavbarMenuItem
                 path="#/admin/user-management"
                 text="User Management"
                 icon={<Icons.Team />}
@@ -257,12 +263,6 @@ export default function AppNavbar({
                   icon={<Icons.Heartbeat />}
                   selected={['ADMIN_DEVICE_STATUS'].includes(page)}
                 /> : null}
-                <AppNavbarMenuItem
-                  path="#/admin/locations"
-                  text="Locations"
-                  icon={<Icons.Globe />}
-                  selected={['ADMIN_LOCATIONS'].includes(page)}
-                />
             </AppNavbarMenu> : null
           }
           <AppNavbarMenu


### PR DESCRIPTION
Reorder navbar dropdown so "locations" is the first item.

In addition (just something I noticed while doing the above work), hide the edit button on the space management pages if the user doesn't have the `core_write` permission.