### PR TITLE
Only track mixpanel if user is logged in

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,11 +114,15 @@ function trackHashChange() {
     }
   }, {});
 
+  const loggedIn = (store.getState() as any).sessionToken !== null;
+
   // Mixpanel: track url chage
-  mixpanelTrack('Pageview', {
-    ...analyticsParameters,
-    url: window.location.hash,
-  });
+  if (loggedIn) {
+    mixpanelTrack('Pageview', {
+      ...analyticsParameters,
+      url: window.location.hash,
+    });  
+  }
 
   // google analytics: track page view
   if (process.env.REACT_APP_GA_TRACKING_CODE) {


### PR DESCRIPTION
Mixpanel charges us based on MTU (monthly tracked users). Anonymous users are counted as individual users.

A lot of MTUs come from un-auth'd users hitting the dashboard. This only tracks pageviews for auth'd users.