### PR TITLE
When deleting a dashboard, also delete it from the collection

### DIFF
--- a/src/actions/dashboards/destroy.ts
+++ b/src/actions/dashboards/destroy.ts
@@ -11,6 +11,7 @@ export default function dashboardsDestroy(dashboard) {
       dispatch(dashboardsError(err));
       return false;
     }
+    dispatch({type: DASHBOARDS_DESTROY, dashboard});
     return true;
   };
 }

--- a/src/components/dashboard-edit/index.tsx
+++ b/src/components/dashboard-edit/index.tsx
@@ -102,7 +102,7 @@ export function DashboardEdit({
         </div>
       ) : null}
 
-      {dashboards.view === 'VISIBLE' ? (
+      {dashboards.view === 'VISIBLE' && selectedDashboard ? (
         <AppFrame>
           <AppPane>
             <AppBar>
@@ -283,12 +283,11 @@ export default connect((state: any) => ({
       callback: async () => {
         const ok = await dispatch<any>(dashboardsDestroy(dashboard));
         if (ok) {
+          window.location.href = `#/dashboards`;
           dispatch<any>(showToast({ text: 'Dashboard deleted successfully' }));
         } else {
           dispatch<any>(showToast({ type: 'error', text: 'Error deleting dashboard' }));
         }
-        // TODO: I am unsure exactly why this won't redirect without the timeout.
-        setTimeout(() => { window.location.href = `#/dashboards`; }, 500);
       }
     }));
   },

--- a/src/reducers/dashboards/index.ts
+++ b/src/reducers/dashboards/index.ts
@@ -6,6 +6,7 @@ import { DASHBOARDS_ERROR } from '../../actions/dashboards/error';
 import { DASHBOARDS_SELECT } from '../../actions/dashboards/select';
 import { DASHBOARDS_UPDATE } from '../../actions/dashboards/update';
 import { DASHBOARDS_DESTROY } from '../../actions/dashboards/destroy';
+import { ROUTE_TRANSITION_DASHBOARD_LIST } from '../../actions/route-transition/dashboard-list';
 import { ROUTE_TRANSITION_DASHBOARD_DETAIL } from '../../actions/route-transition/dashboard-detail';
 import { ROUTE_TRANSITION_DASHBOARD_EDIT } from '../../actions/route-transition/dashboard-edit';
 
@@ -38,7 +39,9 @@ const initialState = {
     }
     */
   },
-  formState: {},
+  formState: {
+    id: undefined,
+  },
   reportList: [],
   timeSegmentLabels: [],
 };
@@ -65,6 +68,10 @@ export default function dashboards(state=initialState, action) {
         }), {})),
       },
     };
+  }
+
+  case ROUTE_TRANSITION_DASHBOARD_LIST: {
+    return { ...state, loading: true, view: 'LOADING' };
   }
 
   case ROUTE_TRANSITION_DASHBOARD_EDIT:
@@ -156,7 +163,9 @@ export default function dashboards(state=initialState, action) {
       ...state,
       view: 'VISIBLE',
       loading: false,
-      data: state.data.map((item: any) => item.id !== action.dashboard.id),
+      selected: state.selected === action.dashboard.id ? null : state.selected,
+      data: state.data.filter((item: any) => item.id !== action.dashboard.id),
+      formState: state.formState.id === action.dashboard.id ? {} : state.formState,
     };
   }
 


### PR DESCRIPTION
Previously, it was not being deleted from the collection. Also, it turns
out that some logic after the dashboard was being deleted was depending
on the dashboard still existing in the reducer, so I reordered a few
things / sdjusted how a few things work to get around that.