### PR TITLE
add dev clusters to the dropdown menu for core api backends

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -20,6 +20,8 @@ export default [
     defaults: {
       'production': 'https://api.density.io/v2',
       'staging': 'https://core-staging.density.io/v2',
+      'dev01': 'https://dev01-us-east-1-api.density.io/v2',
+      'dev02': 'https://dev02-us-east-1-api.density.io/v2',
       'local': 'http://localhost:8000/v2',
       'env (REACT_APP_CORE_API_URL)': process.env.REACT_APP_CORE_API_URL,
     },


### PR DESCRIPTION
Adds dev cluster urls for dev01 and dev02 to the list of available backends for the dashboard.