### PR TITLE
accounts and core must be on the same cluster. 

### DIFF
--- a/src/fields.ts
+++ b/src/fields.ts
@@ -33,6 +33,8 @@ export default [
     defaults: {
       'production': 'https://accounts.density.io/v2',
       'staging': 'https://accounts-staging.density.io/v2',
+      'dev01': 'https://dev01-us-east-1-accounts.density.io/v2',
+      'dev02': 'https://dev02-us-east-1-accounts.density.io/v2',
       'local': 'http://localhost:8000/v2',
       'env (REACT_APP_ACCOUNTS_API_URL)': process.env.REACT_APP_ACCOUNTS_API_URL,
     },


### PR DESCRIPTION
Updated the core api options but not the account api options.  We need both to authenticate using oauth.