### PR TITLE
Absolute date range when creating reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3892,9 +3892,9 @@
       }
     },
     "@density/ui": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/@density/ui/-/ui-17.8.1.tgz",
-      "integrity": "sha512-d0p7Qn8+nyfPzBIj4lNDwDDgTrdndb2jzZaNM35tG1nnx4Ts9jrJHKuMvF0vOA6xjXAkqGRbs3dgKSl9cEW1ZA==",
+      "version": "17.8.0-pre2",
+      "resolved": "https://registry.npmjs.org/@density/ui/-/ui-17.8.0-pre2.tgz",
+      "integrity": "sha512-X/JGzEz6VAq3kJnePUnToB06MRZBfpt/2FA0SViJNRTLLRDzbSFd37PPHxnXiPxS8rIfZSLhTDAXs5+12coTmg==",
       "requires": {
         "@density/react-dates": "^12.6.0",
         "classnames": "^2.2.6",
@@ -26350,14 +26350,14 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-modal": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.8.1.tgz",
-      "integrity": "sha512-aLKeZM9pgXpIKVwopRHMuvqKWiBajkqisDA8UzocdCF6S4fyKVfLWmZR5G1Q0ODBxxxxf2XIwiCP8G/11GJAuw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.9.1.tgz",
+      "integrity": "sha512-k+TUkhGWpIVHLsEyjNmlyOYL0Uz03fNZvlkhCImd1h+6fhNgTi6H6jexVXPVhD2LMMDzJyfugxMN+APN/em+eQ==",
       "requires": {
         "exenv": "^1.2.0",
         "prop-types": "^15.5.10",
         "react-lifecycles-compat": "^3.0.0",
-        "warning": "^3.0.0"
+        "warning": "^4.0.3"
       }
     },
     "react-moment-proptypes": {
@@ -26369,9 +26369,9 @@
       }
     },
     "react-phone-number-input": {
-      "version": "2.3.18",
-      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-2.3.18.tgz",
-      "integrity": "sha512-YmhpGtpezWBpU8UezM5po9NRxEpY7tVRqUyK9J1hhD9cOjv6I2embHO7ligs/lV4CJIpvYntdf4LPvWb4ejO4w==",
+      "version": "2.3.19",
+      "resolved": "https://registry.npmjs.org/react-phone-number-input/-/react-phone-number-input-2.3.19.tgz",
+      "integrity": "sha512-HS9+GKRgB68S1cPuOmrTpBcrycJGwvP00mBwx5aB1NPAstUd0mEpOqE67AHX7bUfe5N9rMd06noy+zP2xeOAdw==",
       "requires": {
         "classnames": "^2.2.5",
         "input-format": "^0.2.2",
@@ -26403,14 +26403,14 @@
       }
     },
     "react-responsive-ui": {
-      "version": "0.14.140",
-      "resolved": "https://registry.npmjs.org/react-responsive-ui/-/react-responsive-ui-0.14.140.tgz",
-      "integrity": "sha512-GPA4dlUXK3DjQOd7nmGhjU2UN0DgBJPydUIAZ1Vsv/BFDw0/LxPWOofvVODU1KS7fyA1WSRLUQx4vbkiKJ/X2w==",
+      "version": "0.14.147",
+      "resolved": "https://registry.npmjs.org/react-responsive-ui/-/react-responsive-ui-0.14.147.tgz",
+      "integrity": "sha512-JO/vDRBt7f6IGPrDuztYKGXmZwsHOzXSVhPtmAxZWDVnu0v25GMfwJ1m09uhKcX1SEacy/vCfDtBuPilWY0+WA==",
       "requires": {
         "classnames": "^2.2.5",
         "create-react-context": "^0.2.2",
         "lodash": "^4.17.4",
-        "prop-types": "^15.5.6",
+        "prop-types": "^15.7.2",
         "react-create-ref": "^1.0.1",
         "react-day-picker": "^7.2.4",
         "react-lifecycles-compat": "^3.0.2",
@@ -30591,9 +30591,9 @@
       }
     },
     "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "requires": {
         "loose-envify": "^1.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3812,7 +3812,7 @@
       "dependencies": {
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
@@ -3835,9 +3835,9 @@
       }
     },
     "@density/reports": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-6.0.0.tgz",
-      "integrity": "sha512-crF5CAaZBTI8URFd0tVOvKrRCooxN0LGZNLsHJTJmreWBGyFZjYgOKtwdGhaRa2sM09yLi0KhuF1dA75Uyi8og==",
+      "version": "6.1.0-pre4",
+      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-6.1.0-pre4.tgz",
+      "integrity": "sha512-DsNBOFTcy5lZ6EHphVrBl8yUaEbhPt/+8IuLJN4ZbNZA1h7bOhSknrdGUZGhaolOxj/xBCM04xtN6o2UtXzyHQ==",
       "requires": {
         "axios": "^0.18.0",
         "classnames": "^2.2.6",
@@ -3845,7 +3845,8 @@
         "comma-number": "^2.0.0",
         "d3-scale": "^2.2.2",
         "d3-shape": "^1.3.4",
-        "qs": "^6.7.0"
+        "qs": "^6.7.0",
+        "react-d3-axis": "^0.1.2"
       },
       "dependencies": {
         "axios": {
@@ -6519,7 +6520,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "requires": {
             "inherits": "2.0.1"
@@ -7233,7 +7234,7 @@
     },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
-      "resolved": "http://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
       "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
       "requires": {
         "babel-plugin-syntax-object-rest-spread": "^6.13.0",
@@ -7336,7 +7337,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -8385,7 +8386,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -8419,7 +8420,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -8483,7 +8484,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -9051,7 +9052,7 @@
     },
     "clone-deep": {
       "version": "0.2.4",
-      "resolved": "http://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
       "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
       "dev": true,
       "requires": {
@@ -9505,7 +9506,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -9517,7 +9518,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -11058,7 +11059,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -11211,7 +11212,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer3": {
@@ -11941,7 +11942,7 @@
         },
         "doctrine": {
           "version": "1.5.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
@@ -12834,7 +12835,7 @@
       "dependencies": {
         "core-js": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
@@ -12921,7 +12922,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",
@@ -13630,7 +13631,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
     "get-value": {
@@ -13758,7 +13759,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "requires": {
         "create-error-class": "^3.0.0",
@@ -14186,7 +14187,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -15019,7 +15020,7 @@
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "requires": {
         "builtin-modules": "^1.0.0"
@@ -15178,7 +15179,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-object": {
@@ -16616,8 +16617,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -16638,14 +16638,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -16660,20 +16658,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -16790,8 +16785,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -16803,7 +16797,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -16818,7 +16811,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -16826,14 +16818,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -16852,7 +16842,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -16933,8 +16922,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -16946,7 +16934,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -17032,8 +17019,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -17069,7 +17055,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17089,7 +17074,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -17133,14 +17117,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -18666,7 +18648,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
@@ -19403,7 +19385,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -19412,8 +19393,7 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "optional": true
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
     },
@@ -19488,7 +19468,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -20283,7 +20263,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -20710,7 +20690,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "debug": {
@@ -26030,6 +26010,11 @@
       "resolved": "https://registry.npmjs.org/react-create-ref/-/react-create-ref-1.0.1.tgz",
       "integrity": "sha512-pryn9uefKa5HPfmgf1Gl93+hwN2rqXeipLSdnq6Q9M7Pd00sx617GyOtluqVoQ0XlvvYJ8Bw/uTorXvH+fgUGQ=="
     },
+    "react-d3-axis": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/react-d3-axis/-/react-d3-axis-0.1.2.tgz",
+      "integrity": "sha512-Id2C208SGcLcIfgrdl9ffgZKXtp3wELV7dC3HJVjim+J0IQiAaZo9APSnlvJE2kB90C7wJKlXdFI1bYPg7jytA=="
+    },
     "react-day-picker": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-7.3.0.tgz",
@@ -28215,7 +28200,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -28236,7 +28221,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
@@ -28560,7 +28545,7 @@
     },
     "source-map": {
       "version": "0.4.4",
-      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
@@ -28806,7 +28791,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -28821,7 +28806,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
@@ -29005,7 +28990,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -29404,7 +29389,7 @@
     },
     "table": {
       "version": "4.0.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "requires": {
         "ajv": "^6.0.1",
@@ -29708,7 +29693,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -29725,7 +29710,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -31668,7 +31653,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3892,9 +3892,9 @@
       }
     },
     "@density/ui": {
-      "version": "17.8.0-pre2",
-      "resolved": "https://registry.npmjs.org/@density/ui/-/ui-17.8.0-pre2.tgz",
-      "integrity": "sha512-X/JGzEz6VAq3kJnePUnToB06MRZBfpt/2FA0SViJNRTLLRDzbSFd37PPHxnXiPxS8rIfZSLhTDAXs5+12coTmg==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@density/ui/-/ui-18.0.1.tgz",
+      "integrity": "sha512-ebvYyxduHEvDnZMOUiTECwG2ntt4QDt+KEmZmJf8YY13jcE5XfejSir8x+7EufcUXDVOlr4LhthtTNdw8f14dQ==",
       "requires": {
         "@density/react-dates": "^12.6.0",
         "classnames": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@density/conduit": "^0.3.0",
     "@density/react-dates": "^12.6.0",
     "@density/reports": "^6.1.0-pre4",
-    "@density/ui": "^17.8.1",
+    "@density/ui": "^17.8.0-pre2",
     "@mapbox/mapbox-gl-geocoder": "^4.0.0",
     "auth0-js": "^9.9.0",
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@density/conduit": "^0.3.0",
     "@density/react-dates": "^12.6.0",
     "@density/reports": "^6.1.0-pre4",
-    "@density/ui": "^17.8.0-pre2",
+    "@density/ui": "^18.0.1",
     "@mapbox/mapbox-gl-geocoder": "^4.0.0",
     "auth0-js": "^9.9.0",
     "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@density/charts": "^1.0.1",
     "@density/conduit": "^0.3.0",
     "@density/react-dates": "^12.6.0",
-    "@density/reports": "^6.0.0",
+    "@density/reports": "^6.1.0-pre4",
     "@density/ui": "^17.8.1",
     "@mapbox/mapbox-gl-geocoder": "^4.0.0",
     "auth0-js": "^9.9.0",

--- a/src/components/dashboard-report-edit-modal/index.tsx
+++ b/src/components/dashboard-report-edit-modal/index.tsx
@@ -2,8 +2,11 @@ import React, { ReactNode, Fragment } from 'react';
 import changeCase from 'change-case';
 import debounce from 'lodash.debounce';
 import { connect } from 'react-redux';
+import moment from 'moment';
 import styles from './styles.module.scss';
 import Report, { REPORTS, TIME_RANGES } from '@density/reports';
+import isOutsideRange from '../../helpers/date-range-picker-is-outside-range';
+import getCommonRangesForSpace from '../../helpers/common-ranges';
 
 import {
   DensityReport,
@@ -25,6 +28,7 @@ import {
   Modal,
   RadioButton,
   Switch,
+  DateRangePicker,
 } from '@density/ui';
 
 import updateModal from '../../actions/modal/update';
@@ -51,6 +55,12 @@ import FormLabel from '../form-label';
 
 import spaceHierarchyFormatter, { SpaceHierarchyDisplayItem } from '../../helpers/space-hierarchy-formatter';
 import filterCollection from '../../helpers/filter-collection';
+import TIME_ZONE_CHOICES from '../../helpers/time-zone-choices';
+import {
+  formatForReactDates,
+  parseFromReactDates,
+  parseISOTimeAtSpace,
+} from '../../helpers/space-time-utilities';
 
 type DashboardReportModalProps = {
   activeModal: {
@@ -509,23 +519,149 @@ function DashboardReportEditModal({
                       break;
 
                     case 'TIME_RANGE_PICKER':
-                      input = (
-                        <InputBox
-                          type="select"
-                          id={id}
-                          width="100%"
-                          value={activeModal.data.report.settings[fieldName]}
-                          choices={[
-                            {id: TIME_RANGES.LAST_WEEK, label: 'Last Week' },
-                            {id: TIME_RANGES.LAST_4_WEEKS, label: 'Last 4 weeks' },
-                            {id: TIME_RANGES.WEEK_TO_DATE, label: 'Week to date' },
-                            {id: TIME_RANGES.LAST_7_DAYS, label: 'Last 7 days' },
-                            {id: TIME_RANGES.LAST_28_DAYS, label: 'Last 28 days' },
-                          ]}
-                          onChange={choice => reportUpdateSettings(fieldName, choice.id)}
-                        />
+                      return (
+                        <Fragment key={control.label}>
+
+                          {/* The main time range selector */}
+                          <FormLabel
+                            label={control.label}
+                            key={control.label}
+                            htmlFor={id}
+                            input={<InputBox
+                              type="select"
+                              id={id}
+                              width="100%"
+                              value={
+                                activeModal.data.report.settings[fieldName].type ||
+                                activeModal.data.report.settings[fieldName]
+                              }
+                              choices={[
+                                {id: TIME_RANGES.LAST_WEEK, label: 'Last Week' },
+                                {id: TIME_RANGES.LAST_4_WEEKS, label: 'Last 4 weeks' },
+                                {id: TIME_RANGES.WEEK_TO_DATE, label: 'Week to date' },
+                                {id: TIME_RANGES.LAST_7_DAYS, label: 'Last 7 days' },
+                                {id: TIME_RANGES.LAST_28_DAYS, label: 'Last 28 days' },
+                                {id: 'CUSTOM_RANGE', label: 'Absolute time period...' },
+                              ]}
+                              onChange={choice => {
+                                if (choice.id === 'CUSTOM_RANGE') {
+                                  reportUpdateSettings(fieldName, {
+                                    type: 'CUSTOM_RANGE',
+                                    displayTimeZone: 'America/New_York',
+                                    startDate: moment.tz('America/New_York').subtract(7, 'days').startOf('day').format(),
+                                    endDate: moment.tz('America/New_York').subtract(1, 'day').startOf('day').format(),
+                                  });
+                                } else {
+                                  reportUpdateSettings(fieldName, choice.id);
+                                }
+                              }}
+                            />}
+                            required={control.parameters.required}
+                          />
+
+                          {/* If custom range was picked, show some other options */}
+                          {activeModal.data.report.settings[fieldName].type === 'CUSTOM_RANGE' ? (
+                            <Fragment>
+                              <FormLabel
+                                label="Time Zone"
+                                key={`${control.label} Time Zone`}
+                                htmlFor={id}
+                                input={<InputBox
+                                  type="select"
+                                  choices={TIME_ZONE_CHOICES}
+                                  menuMaxHeight={300}
+                                  width="100%"
+                                  value={activeModal.data.report.settings[fieldName].displayTimeZone}
+                                  onChange={choice => {
+                                    reportUpdateSettings(fieldName, {
+                                      ...activeModal.data.report.settings[fieldName],
+                                      displayTimeZone: choice.id,
+                                    });
+                                  }}
+                                />}
+                                required={control.parameters.required}
+                              />
+                              <FormLabel
+                                label="Date Range"
+                                key={`${control.label} Date Range`}
+                                htmlFor={id}
+                                input={<DateRangePicker
+                                  startDate={formatForReactDates(
+                                    moment.tz(
+                                      activeModal.data.report.settings[fieldName].startDate,
+                                      activeModal.data.report.settings[fieldName].displayTimeZone,
+                                    ),
+                                    {timeZone: activeModal.data.report.settings[fieldName].displayTimeZone},
+                                  )}
+                                  endDate={formatForReactDates(
+                                    moment.tz(
+                                      activeModal.data.report.settings[fieldName].endDate,
+                                      activeModal.data.report.settings[fieldName].displayTimeZone,
+                                    ),
+                                    {timeZone: activeModal.data.report.settings[fieldName].displayTimeZone},
+                                  )}
+                                  numberOfMonths={1}
+                                  onChange={({startDate, endDate}) => {
+                                    if (startDate) {
+                                      startDate = parseFromReactDates(startDate, {
+                                        timeZone: activeModal.data.report.settings[fieldName].displayTimeZone,
+                                      }).startOf('day');
+                                    } else {
+                                      startDate = parseISOTimeAtSpace(
+                                        activeModal.data.report.settings[fieldName].startDate,
+                                        {
+                                          timeZone: activeModal.data.report.settings[fieldName].displayTimeZone,
+                                        }
+                                      );
+                                    }
+                                    if (endDate) {
+                                      endDate = parseFromReactDates(endDate, {
+                                        timeZone: activeModal.data.report.settings[fieldName].displayTimeZone,
+                                      }).endOf('day');
+                                    } else {
+                                      endDate = parseISOTimeAtSpace(
+                                        activeModal.data.report.settings[fieldName].endDate,
+                                        {
+                                          timeZone: activeModal.data.report.settings[fieldName].displayTimeZone,
+                                        }
+                                      );
+                                    }
+
+                                    reportUpdateSettings(fieldName, {
+                                      ...activeModal.data.report.settings[fieldName],
+                                      startDate: startDate.format(),
+                                      endDate: endDate.format(),
+                                    });
+                                  }}
+                                  isOutsideRange={day => isOutsideRange({
+                                    timeZone: activeModal.data.report.settings[fieldName].displayTimeZone,
+                                  }, day)}
+                                  // Within the component, store if the user has selected the start of end date picker
+                                  // input
+                                  focusedInput={activeModal.data.report.settings[fieldName].datePickerInput}
+                                  onFocusChange={(focused, a) => {
+                                    reportUpdateSettings(fieldName, {
+                                      ...activeModal.data.report.settings[fieldName],
+                                      datePickerInput: focused,
+                                    });
+                                  }}
+                                  commonRanges={getCommonRangesForSpace({
+                                    timeZone: activeModal.data.report.settings[fieldName].displayTimeZone,
+                                  })}
+                                  onSelectCommonRange={({startDate, endDate}) => {
+                                    reportUpdateSettings(fieldName, {
+                                      ...activeModal.data.report.settings[fieldName],
+                                      startDate: startDate.format(),
+                                      endDate: endDate.format(),
+                                    });
+                                  }}
+                                />}
+                                required={control.parameters.required}
+                              />
+                            </Fragment>
+                          ) : null}
+                        </Fragment>
                       );
-                      break;
 
                     case 'PERCENTAGE':
                       input = (


### PR DESCRIPTION
Adds a new option to the report creation modal time range selector for absolute date range. When picked, it shows a date range picker (with the new `SMALL_WIDTH` context) and a timezone box to ensure that the date range is localized to a single time zone (as reports with multiple spaces make this difficult).

To make the time zone box a bit better though, if the report is a single space report and you have a space selected when selecting "absolute date range", it will auto populate the time zone based on the single space that was selected.

![Screen Shot 2019-07-16 at 11 26 37 AM](https://user-images.githubusercontent.com/1704236/61307908-24d35d00-a7bd-11e9-9cfe-e76e1ffed458.png)

