### PR TITLE
Adjust function signature of `onChangeCommonRange` in common range date range picker callback

### DIFF
--- a/src/components/explore-control-bar/index.tsx
+++ b/src/components/explore-control-bar/index.tsx
@@ -163,10 +163,11 @@ export function ExploreControlBarRaw({
               commonRanges={getCommonRangesForSpace(selectedSpace)}
               onSelectCommonRange={({startDate, endDate}) => {
                 onChangeDateRange(
+                  activePage,
                   selectedSpace,
+                  {...filters, startDate, endDate},
                   formatInISOTime(startDate),
                   formatInISOTime(endDate),
-                  {...filters, startDate, endDate}
                 );
               }}
             />


### PR DESCRIPTION
I think when this was last refactored, the signature of `onChangeDateRange`
changed, and it wasn't updated in all the places it should have been.