### PR TITLE
Add validation tag for insightappsec for scanning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="">
     <meta name="theme-color" content="#000000">
+    <meta name="insight-app-sec-validation" content="36982a13-3f53-48ef-9446-cf44dc23aa05">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/


### PR DESCRIPTION
Adds a metatag for validation with insightappsec:

https://www.rapid7.com/products/insightappsec/

The tag includes a randomly generated token to identify the domain to be scanned (e.g., prove we own the domain and are scanning for legitimate purposes).  

