### PR TITLE
New spaces page tweaks

### DIFF
--- a/src/components/spaces-report-controller/styles.module.scss
+++ b/src/components/spaces-report-controller/styles.module.scss
@@ -38,6 +38,7 @@
   border: 1px solid $gray;
   border-radius: $borderRadiusBase;
   box-shadow: 8px 8px 0px rgba(0, 0, 0, 0.05);
+  line-height: 22px;
   height: 72px;
 
   padding-left: 24px;

--- a/src/components/spaces/index.tsx
+++ b/src/components/spaces/index.tsx
@@ -156,7 +156,8 @@ export function SpacesRaw () {
                       formattedHierarchy={formattedHierarchy}
                       selectControl={SelectControlTypes.NONE}
                       onChange={item => {
-                        window.location.href = getHashRoute(item.space, activePage);
+                        const space = spaces.data.find(s => s.id === item.space.id);
+                        window.location.href = getHashRoute(space, activePage);
                       }}
                       isItemDisabled={item => {
                         const space = spaces.data.find(s => s.id === item.space.id);
@@ -263,22 +264,35 @@ export function SpacesRaw () {
             {/* New controller for meetings page */}
             {activePage === 'SPACES_SPACE_MEETINGS' && selectedSpace ?
               spaceReports.controllers.filter(x => x.key === 'meetings_page_controller').map(controller => (
-                <SpacesReportController
-                  key={controller.key}
-                  space={selectedSpace}
-                  spaceHierarchy={spaceHierarchy.data}
-                  controller={controller}
-                  onUpdateControls={(key, value) => {
-                    const updated = {
-                      ...controller,
-                      controls: controller.controls.map(control => {
-                        return control.key === key ? {...control, ...value} : control;
-                      })
-                    };
-                    dispatch(spacesUpdateReportController(selectedSpace, updated));
-                    dispatch(spaceReportsCalculateReportData(updated, selectedSpace));
-                  }}
-                />
+                (selectedSpace.spaceMappings || []).length ?
+                  <SpacesReportController
+                    key={controller.key}
+                    space={selectedSpace}
+                    spaceHierarchy={spaceHierarchy.data}
+                    controller={controller}
+                    onUpdateControls={(key, value) => {
+                      const updated = {
+                        ...controller,
+                        controls: controller.controls.map(control => {
+                          return control.key === key ? {...control, ...value} : control;
+                        })
+                      };
+                      dispatch(spacesUpdateReportController(selectedSpace, updated));
+                      dispatch(spaceReportsCalculateReportData(updated, selectedSpace));
+                    }}
+                  /> :
+                  <div style={{ width: '100%', height: '100%', background: SPACES_BACKGROUND }}>
+                    <div className={styles.centeredMessage}>
+                      <div className={styles.roomBookingMessage}>
+                        <span>
+                          Please set up a{' '}
+                          <a href="#/admin/integrations">room booking integration</a>
+                          {' '}to view meeting data for this space.
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  
               )) : null}
 
             {/* Old components for other pages */}

--- a/src/components/spaces/index.tsx
+++ b/src/components/spaces/index.tsx
@@ -42,6 +42,27 @@ import hideModal from '../../actions/modal/hide';
 
 export const SPACES_BACKGROUND = '#FAFAFA';
 
+function hasMeetingsPage(space) {
+  return ['conference_room', 'meeting_room'].includes(space.function);
+}
+
+function getHashRoute(space, activePage) {
+  switch(activePage) {
+    case 'SPACES_SPACE_TRENDS':
+      return `#/spaces/${space.id}/trends`;
+    case 'SPACES_SPACE_DAILY':
+      return `#/spaces/${space.id}/daily`;
+    case 'SPACES_SPACE_DATA_EXPORT':
+      return `#/spaces/${space.id}/data-export`;
+    case 'SPACES_SPACE_MEETINGS':
+      return hasMeetingsPage(space) ?
+        `#/spaces/${space.id}/meetings` :
+        `#/spaces/${space.id}/trends`;
+    default:
+      return `#/spaces/${space.id}/trends`;
+  }
+}
+
 function ExploreSpacePage({ activePage }) {
   switch(activePage) {
     case 'SPACES_SPACE_DAILY':
@@ -131,10 +152,12 @@ export function SpacesRaw () {
                   selectedSpace ?
                     <SpacePicker
                       value={formattedHierarchy.find(x => x.space.id === selectedSpace.id) || null}
-                      onChange={item => window.location.href = `#/spaces/${item.space.id}/trends`}
                       showSearchBox={false}
                       formattedHierarchy={formattedHierarchy}
                       selectControl={SelectControlTypes.NONE}
+                      onChange={item => {
+                        window.location.href = getHashRoute(item.space, activePage);
+                      }}
                       isItemDisabled={item => {
                         const space = spaces.data.find(s => s.id === item.space.id);
                         return !space || !space.doorways.length;
@@ -154,25 +177,25 @@ export function SpacesRaw () {
                 <AppBarSubnav>
                   <AppBarSubnavLink
                     href={`#/spaces/${selectedSpace.id}/trends`}
-                    active={activePage === "SPACES_SPACE_TRENDS"}
+                    active={activePage === 'SPACES_SPACE_TRENDS'}
                   >
                     Trends
                   </AppBarSubnavLink>
                   <AppBarSubnavLink
                     href={`#/spaces/${selectedSpace.id}/daily`}
-                    active={activePage === "SPACES_SPACE_DAILY"}
+                    active={activePage === 'SPACES_SPACE_DAILY'}
                   >
                     Daily
                   </AppBarSubnavLink>
-                  { ["conference_room", "meeting_room"].includes(selectedSpace.function) ? <AppBarSubnavLink
+                  { hasMeetingsPage(selectedSpace) ? <AppBarSubnavLink
                     href={`#/spaces/${selectedSpace.id}/meetings`}
-                    active={activePage === "SPACES_SPACE_MEETINGS"}
+                    active={activePage === 'SPACES_SPACE_MEETINGS'}
                   >
                     Meetings
                   </AppBarSubnavLink> : null }
                   <AppBarSubnavLink
                     href={`#/spaces/${selectedSpace.id}/data-export`}
-                    active={activePage === "SPACES_SPACE_DATA_EXPORT"}
+                    active={activePage === 'SPACES_SPACE_DATA_EXPORT'}
                   >
                     Data Export
                   </AppBarSubnavLink>

--- a/src/components/spaces/styles.module.scss
+++ b/src/components/spaces/styles.module.scss
@@ -1,4 +1,5 @@
 @import "@density/ui/variables/colors.scss";
+@import "@density/ui/variables/spacing.scss";
 
 .appFrameWrapper {
   display: flex;
@@ -130,4 +131,27 @@
   margin-left: 24px;
   margin-top: 20px;
   color: $grayLight;
+}
+
+.centeredMessage {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+}
+
+.roomBookingMessage {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  background-color: #fff;
+  border: 1px solid $gray;
+  border-radius: $borderRadiusBase;
+  box-shadow: 8px 8px 0px rgba(0, 0, 0, 0.05);
+  line-height: 22px;
+  height: 72px;
+  width: 320px;
+
+  padding-left: 24px;
+  padding-right: 24px;
 }

--- a/src/helpers/use-auto-width/index.ts
+++ b/src/helpers/use-auto-width/index.ts
@@ -27,6 +27,6 @@ export function useAutoWidth(ref, delay = 300) {
     [ref, delay]
   );
   useEventListener('resize', handler);
-  useEffect(() => handler() && undefined, []);
+  useEffect(() => handler() && undefined, [handler]);
   return width;
 }


### PR DESCRIPTION
- Preserve the "tab" that the user is on when switching spaces
- Add a message and link to the integrations admin when viewing a meeting room with no space mapping