### PR TITLE
Set default value for INSIGHT_LIST report control type

### DIFF
--- a/src/components/dashboard-report-edit-modal/index.tsx
+++ b/src/components/dashboard-report-edit-modal/index.tsx
@@ -1022,6 +1022,10 @@ export default connect((state: any) => ({
         value = control.parameters.defaultValue || 0.5;
         break;
 
+      case 'INSIGHT_LIST':
+        value = control.parameters.defaultValue || [];
+        break;
+
       default:
         value = control.parameters.defaultValue || '';
         break;


### PR DESCRIPTION
No default value was being set for the INSIGHT_LIST report control type,
causing the prop being passed to the report component to be not an array which
caused problems.