### PR TITLE
use expect.toThrowError to avoid node version dependency in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.16
+      - image: circleci/node:12.7
     resource_class: large
     steps:
       - checkout
@@ -30,7 +30,7 @@ jobs:
 
   preview:
     docker:
-      - image: circleci/node:10.16
+      - image: circleci/node:12.7
     resource_class: medium
     steps:
       - checkout
@@ -67,7 +67,7 @@ jobs:
 
   preview-storybook:
     docker:
-      - image: circleci/node:10.7.0
+      - image: circleci/node:12.7
     resource_class: small
     steps:
       - checkout
@@ -96,7 +96,7 @@ jobs:
 
   staging:
     docker:
-      - image: circleci/node:10.16
+      - image: circleci/node:12.7
     resource_class: medium
     steps:
       - checkout
@@ -131,7 +131,7 @@ jobs:
 
   production:
     docker:
-      - image: circleci/node:10.16
+      - image: circleci/node:12.7
     resource_class: medium
     steps:
       - checkout

--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "not op_mini all"
   ],
   "engines": {
-    "node": ">=12.4.0"
+    "node": ">=12.7.0"
   }
 }

--- a/src/helpers/filter-hierarchy/index.test.js
+++ b/src/helpers/filter-hierarchy/index.test.js
@@ -28,9 +28,9 @@ describe('filter-hierarchy', function() {
     });
     it('should throw an error if a node in the tree cannot be found', function() {
       const peaches = hierarchy.find(i => i.name === 'Peaches');
-      assert.throws(() => {
+      expect(() => {
         getParentsOfSpace(hierarchy, peaches);
-      }, new Error('No such space found with id 999999999'));
+      }).toThrowError('No such space found with id 999999999');
     });
     it('should only return the root node when given the root node', function() {
       const food = hierarchy.find(i => i.name === 'Food');
@@ -40,9 +40,9 @@ describe('filter-hierarchy', function() {
       );
     });
     it('should throw an error if an invalid space is passed to the function', function() {
-      assert.throws(() => {
+      expect(() => {
         getParentsOfSpace(hierarchy, null);
-      }, new Error('Invalid space passed to getParentsOfSpace'));
+      }).toThrowError('Invalid space passed to getParentsOfSpace')
     });
     it('should not infinitely loop if given bad data', function() {
       assert.deepEqual(

--- a/src/helpers/unsafe-set-settings-flag/index.test.js
+++ b/src/helpers/unsafe-set-settings-flag/index.test.js
@@ -56,8 +56,8 @@ describe('set-settings-flag', function() {
 
     // Update a setting, and verify that the helper fails with an error.
     const setSettingsFlag = setSettingsFlagConstructor(store);
-    assert.throws(() => {
+    expect(() => {
       setSettingsFlag('key', 'value');
-    }, new Error('Please wait for the user collection to load before changing settings flags.'));
+    }).toThrowError('Please wait for the user collection to load before changing settings flags.')
   });
 });


### PR DESCRIPTION
Used the jest built-in `expect(thing).toThrowError()` rather than nodejs built-in `assert.throws(thing)`

Tests should now be able to run from node v10 and v12