### PR TITLE
Update scope of slackbot

### DIFF
--- a/src/components/admin-integrations/index.tsx
+++ b/src/components/admin-integrations/index.tsx
@@ -237,7 +237,7 @@ export function AdminIntegrations({
             template={item => !item.serviceAuthorization.id ? <ListViewClickableLink>Activate</ListViewClickableLink> : null }
             onClick={item => {
               if (!item.serviceAuthorization.id) {
-                window.location.href = `https://slack.com/oauth/authorize?client_id=${process.env.REACT_APP_SLACK_CLIENT_ID}&scope=channels:read chat:write:bot&redirect_uri=${process.env.REACT_APP_SLACK_REDIRECT_URL}` 
+                window.location.href = `https://slack.com/oauth/authorize?client_id=${process.env.REACT_APP_SLACK_CLIENT_ID}&scope=chat:write:bot&redirect_uri=${process.env.REACT_APP_SLACK_REDIRECT_URL}` 
               }
             }}
           />


### PR DESCRIPTION
We don't need `channels:read` permission and Stripe won't activate the bot until we remove it.