### PR TITLE
fix: filter was allowing duplicate future counts to be shown

### DIFF
--- a/src/components/analytics-line-chart/index.tsx
+++ b/src/components/analytics-line-chart/index.tsx
@@ -242,20 +242,20 @@ const ChartView: React.FunctionComponent<{
     isHovered: false
   });
 
-  const endOfCurrentHour = moment.utc().endOf('hour').valueOf();
+  const endOfCurrentMinute = moment.utc().endOf('minute').valueOf();
 
   // This filters out hidden spaces (table checkboxes) and also removes datapoints in the future (API bug)
   const visibleDatapoints = useMemo(() => {
     return report.queryResult.data.datapoints
       .filter(datapoint => {
         const isCheckedInTable = !report.hiddenSpaceIds.includes(datapoint.spaceId);
-        const isNotInTheFuture = datapoint.startActualEpochTime < endOfCurrentHour;
+        const isNotInTheFuture = datapoint.startActualEpochTime < endOfCurrentMinute;
         return isCheckedInTable && isNotInTheFuture;
       })
   }, [
     report.queryResult.data.datapoints,
     report.hiddenSpaceIds,
-    endOfCurrentHour,
+    endOfCurrentMinute,
   ])  
 
   const LEGEND_TOOLTIP = hoverState.isHovered ? (


### PR DESCRIPTION
Fixes a bug where duplicate (future, nonexistent) counts were being shown.

I memoized this based on the timestamp, but made it ceil to the nearest hour to avoid constant re-rendering. This change reduces that to the nearest minute, which is fine for performance purposes but is too small an interval to cause the bug to be noticed by a user.