### PR TITLE
[imp-90] Low power mode support

### DIFF
--- a/src/components/admin-device-status/index.tsx
+++ b/src/components/admin-device-status/index.tsx
@@ -104,13 +104,13 @@ export function AdminDeviceStatus({
     <div className={styles.lowPowerWarningSection}>
       <div className={styles.lowPowerWarningAlert}>
         <Icons.Danger color='#f4ab4e'/>
-        <h3 className={styles.lowPowerWarningTitle}>
+        <h4 className={styles.lowPowerWarningTitle}>
           {numLowPowerSensors} DPUs are not counting due to insufficient power. Please&nbsp;
           <span
             className={styles.lowPowerWarningLink}
             onClick={openIntercom}>reach out to customer support.
           </span>
-        </h3>
+        </h4>
       </div>
     </div>
   ) : null;

--- a/src/components/admin-device-status/index.tsx
+++ b/src/components/admin-device-status/index.tsx
@@ -9,7 +9,8 @@ import {
   InputBox,
   ListView,
   ListViewColumn,
-  ListViewColumnSpacer
+  ListViewColumnSpacer,
+  Icons
 } from '@density/ui';
 import colorVariables from '@density/ui/variables/colors.json';
 import useRxStore from '../../helpers/use-rx-store';
@@ -17,6 +18,8 @@ import SpacesStore from '../../rx-stores/spaces';
 import SensorsStore from '../../rx-stores/sensors';
 import filterCollection from '../../helpers/filter-collection/index';
 import { ItemList } from '../analytics-control-bar-utilities';
+// @ts-ignore
+import { IntercomAPI } from 'react-intercom';
 
 
 const sensorsFilter = filterCollection({ fields: ['serialNumber', 'doorwayName'] });
@@ -48,6 +51,10 @@ function getStatusText(status) {
   }
 }
 
+function openIntercom(e) {
+  IntercomAPI('show');
+}
+
 
 export function NetworkAddressElement({
   item,
@@ -74,15 +81,21 @@ export function AdminDeviceStatus({
   sensors,
   spaces
 }) {
+
+  if (sensors.data.length){
+    sensors.data[0].status = 'low_power';
+  }
   const [ sensorsFilterText, setSensorsFilterText ] = useState('');
   let sortedSensors = sensorsFilter(sensors.data, sensorsFilterText).sort(function(a, b){
     if (a.status === 'low_power') {
       return -1;
     }
-    if (a.status < b.status)
+    if (a.status < b.status) {
       return -1;
-    if (a.status > b.status)
+    }
+    if (a.status > b.status) {
       return 1;
+    }
     return 0;
   });
 
@@ -90,19 +103,14 @@ export function AdminDeviceStatus({
   const lowPowerAlert = numLowPowerSensors > 0 ? (
     <div className={styles.lowPowerWarningSection}>
       <div className={styles.lowPowerWarningAlert}>
-        <h3 className={styles.lowPowerWarningTitle}>{numLowPowerSensors} DPUs are not counting due to insufficient power</h3>
-        <p>To get your DPUs up and running, we recommend the following:</p>
-        <ul>
-          <li>
-            Confirm the ethernet cords are fully plugged into each DPU and attached power source.
-          </li>
-          <li>
-            If using a power injector: try swapping with a new injector, if available.
-          </li>
-          <li>
-            If using a switch: confirm that the switch is PoE+ with a capacity of 30W for each port and a total switch capacity of 30W * # of DPUs. E.g. if you have 3 DPUs attached to 1 switch, you'll need at least a 90W capacity switch.
-          </li>
-        </ul>
+        <Icons.Danger color='#f4ab4e'/>
+        <h3 className={styles.lowPowerWarningTitle}>
+          {numLowPowerSensors} DPUs are not counting due to insufficient power. Please&nbsp;
+          <span
+            className={styles.lowPowerWarningLink}
+            onClick={openIntercom}>reach out to customer support.
+          </span>
+        </h3>
       </div>
     </div>
   ) : null;

--- a/src/components/admin-device-status/styles.module.scss
+++ b/src/components/admin-device-status/styles.module.scss
@@ -1,4 +1,21 @@
+@import "@density/ui/variables/colors.scss";
+
 .adminDeviceList {
   padding: 24px;
   padding-bottom: 64px;
+}
+
+.lowPowerWarningSection {
+  padding: 24px;
+  background-color: $grayLightest;
+}
+
+.lowPowerWarningAlert {
+  border-radius : 4px;
+  background-color: #ffeed6;
+  padding: 16px;
+}
+
+.lowPowerWarningTitle {
+  color: #f4ab4e;
 }

--- a/src/components/admin-device-status/styles.module.scss
+++ b/src/components/admin-device-status/styles.module.scss
@@ -20,7 +20,9 @@
 .lowPowerWarningTitle {
   margin-bottom: 0;
   margin-left: 8px;
-  color: #f4ab4e;
+  color: $grayDarkest;
+  text-decoration: none;
+  line-height: 1.5
 }
 
 .lowPowerWarningLink {

--- a/src/components/admin-device-status/styles.module.scss
+++ b/src/components/admin-device-status/styles.module.scss
@@ -14,8 +14,17 @@
   border-radius : 4px;
   background-color: #ffeed6;
   padding: 16px;
+  display: flex;
 }
 
 .lowPowerWarningTitle {
+  margin-bottom: 0;
+  margin-left: 8px;
   color: #f4ab4e;
 }
+
+.lowPowerWarningLink {
+  text-decoration: underline;
+  cursor: pointer;
+}
+


### PR DESCRIPTION
Adds visibility into DPUs that are in low power mode, and prompts for remedy when 1 or more fall into that category. 

![image](https://user-images.githubusercontent.com/490270/69891107-0bdccb80-12c8-11ea-9774-316562bb6d2c.png)

@rjgrazioli I took at stab at the styling for the warning pane, feel free to let me know how 
I should improve it.

Coupled with DensityCo/dashboard#610 (but can be deployed in any order)
