### PR TITLE
Two overnight reports for "spaces" page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,9 +1530,9 @@
       }
     },
     "@density/reports": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-15.1.1.tgz",
-      "integrity": "sha512-y7a6d50W4cAB4gkmr6IVNWd3Xp6JmvM1LjpAr4sYUzAoVC4B3YCOO6mzYUx/D1nJegTjFFrmZnnbSVOtNA4kYg==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-15.1.7.tgz",
+      "integrity": "sha512-gOMdzawSSKyMbgn7Vdd91sRwHw5msWZY0N0wr2afdQMybX8Dwdp6cWzOwSvNmwoBllDYN5mjdum9fFFkKrd5Nw==",
       "requires": {
         "@density/lib-time-helpers": "^0.2.5",
         "axios": "^0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,9 +1530,9 @@
       }
     },
     "@density/reports": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-15.1.0.tgz",
-      "integrity": "sha512-GwlPWfpudLS8u7hgPwmN5Y5Lp2RQeFkvJO14jNGByExkc9B/6xoCUcikurDHwKtFvZnUFI12AJd0+mfH0d711A==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-15.1.1.tgz",
+      "integrity": "sha512-y7a6d50W4cAB4gkmr6IVNWd3Xp6JmvM1LjpAr4sYUzAoVC4B3YCOO6mzYUx/D1nJegTjFFrmZnnbSVOtNA4kYg==",
       "requires": {
         "@density/lib-time-helpers": "^0.2.5",
         "axios": "^0.19.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,11 +1530,11 @@
       }
     },
     "@density/reports": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-14.2.2.tgz",
-      "integrity": "sha512-sg8PIHnrfbzwHk2/vB8cBo8ygCH1dGIXoENStQDxxQmsGoCcOA4Ls2rEGqzWTRN8lb0ZeGd30aQ69n+AWeGOGg==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-15.0.2.tgz",
+      "integrity": "sha512-xefze8/YLVYNGYpemb35ok+vRWr4tucwBI7zpw6exNo7A8dcjmsIl0yST9Jzy8M3E7CC3/JwU8jLiOd7e6bQGg==",
       "requires": {
-        "@density/lib-time-helpers": "^0.1.7",
+        "@density/lib-time-helpers": "^0.2.5",
         "axios": "^0.19.0",
         "classnames": "^2.2.6",
         "color-blend": "^2.0.3",
@@ -1546,6 +1546,20 @@
         "qs": "^6.7.0",
         "react-d3-axis": "^0.1.2",
         "snarkdown": "^1.2.2"
+      },
+      "dependencies": {
+        "@density/lib-time-helpers": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/@density/lib-time-helpers/-/lib-time-helpers-0.2.5.tgz",
+          "integrity": "sha512-A8I38+eWZLwbnEtlIM1O9Xd1ocPRmWJ2beKwJijpNhvmt+AeQW/nziCrcOROLJIv1qaPryEA+X+qh5rh8VOAWA==",
+          "requires": {
+            "@density/lib-api-types": "^2.0.0",
+            "@density/lib-common-helpers": "^0.1.4",
+            "@density/lib-common-types": "^1.0.0",
+            "moment": "^2.24.0",
+            "moment-timezone": "^0.5.27"
+          }
+        }
       }
     },
     "@density/ui": {
@@ -9786,7 +9800,7 @@
       "dependencies": {
         "globby": {
           "version": "6.1.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
@@ -9799,7 +9813,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -15961,7 +15975,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
@@ -16082,7 +16096,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -17041,7 +17055,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,9 +1530,9 @@
       }
     },
     "@density/reports": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-15.0.2.tgz",
-      "integrity": "sha512-xefze8/YLVYNGYpemb35ok+vRWr4tucwBI7zpw6exNo7A8dcjmsIl0yST9Jzy8M3E7CC3/JwU8jLiOd7e6bQGg==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/@density/reports/-/reports-15.1.0.tgz",
+      "integrity": "sha512-GwlPWfpudLS8u7hgPwmN5Y5Lp2RQeFkvJO14jNGByExkc9B/6xoCUcikurDHwKtFvZnUFI12AJd0+mfH0d711A==",
       "requires": {
         "@density/lib-time-helpers": "^0.2.5",
         "axios": "^0.19.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@density/lib-space-helpers": "^0.2.3",
     "@density/lib-time-helpers": "^0.1.8",
     "@density/react-dates": "^12.6.0",
-    "@density/reports": "^15.0.2",
+    "@density/reports": "^15.1.0",
     "@density/ui": "^21.5.0",
     "@mapbox/mapbox-gl-geocoder": "^4.5.0",
     "@material-ui/core": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@density/lib-space-helpers": "^0.2.3",
     "@density/lib-time-helpers": "^0.1.8",
     "@density/react-dates": "^12.6.0",
-    "@density/reports": "^15.1.0",
+    "@density/reports": "^15.1.1",
     "@density/ui": "^21.5.0",
     "@mapbox/mapbox-gl-geocoder": "^4.5.0",
     "@material-ui/core": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@density/lib-space-helpers": "^0.2.3",
     "@density/lib-time-helpers": "^0.1.8",
     "@density/react-dates": "^12.6.0",
-    "@density/reports": "^14.2.2",
+    "@density/reports": "^15.0.2",
     "@density/ui": "^21.5.0",
     "@mapbox/mapbox-gl-geocoder": "^4.5.0",
     "@material-ui/core": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@density/lib-space-helpers": "^0.2.3",
     "@density/lib-time-helpers": "^0.1.8",
     "@density/react-dates": "^12.6.0",
-    "@density/reports": "^15.1.1",
+    "@density/reports": "^15.1.7",
     "@density/ui": "^21.5.0",
     "@mapbox/mapbox-gl-geocoder": "^4.5.0",
     "@material-ui/core": "^4.7.1",

--- a/src/components/dashboard-report-edit-modal/index.tsx
+++ b/src/components/dashboard-report-edit-modal/index.tsx
@@ -137,7 +137,7 @@ function getEmptyRequiredFields(report) {
     .filter(control => control.parameters.required)
     .filter(control => {
       const value = report.settings[control.parameters.field];
-      return !value || value.length === 0;
+      return value === undefined || value === null || value.length === 0;
     });
 }
 

--- a/src/components/spaces-reports/index.tsx
+++ b/src/components/spaces-reports/index.tsx
@@ -326,34 +326,48 @@ export function DailyExits(props: SpacesReportProps) {
   />;
 }
 
-const entrancesPerHourOtherSettings = {
+const entrancesPerHourOtherSettingsTimeSegmentSelected = {
+  metric: 'VISITS',
+  aggregation: 'NONE',
+  include_weekends: true,
+};
+const entrancesPerHourOtherSettingsTimeSegmentNotSelected = {
   metric: 'VISITS',
   aggregation: 'NONE',
   include_weekends: true,
   hour_start: 6,
-  hour_end: 20
+  hour_end: 20,
 };
 export function EntrancesPerHour(props: SpacesReportProps) {
   return <EphemeralReport
     name="Entrances per Hour"
     type="HOURLY_BREAKDOWN"
-    otherSettings={entrancesPerHourOtherSettings}
+    otherSettings={props.timeSegmentLabel === DEFAULT_TIME_SEGMENT_LABEL ? 
+      entrancesPerHourOtherSettingsTimeSegmentNotSelected :
+      entrancesPerHourOtherSettingsTimeSegmentSelected}
     {...props}
   />;
 }
 
-const averagePeakOccupancyPerHourOtherSettings = {
+const averagePeakOccupancyPerHourOtherSettingsTimeSegmentSelected = {
+  metric: 'PEAKS',
+  aggregation: 'AVERAGE',
+  include_weekends: true,
+};
+const averagePeakOccupancyPerHourOtherSettingsTimeSegmentNotSelected = {
   metric: 'PEAKS',
   aggregation: 'AVERAGE',
   include_weekends: true,
   hour_start: 6,
-  hour_end: 20
+  hour_end: 20,
 };
 export function AveragePeakOccupancyPerHour(props: SpacesReportProps) {
   return <EphemeralReport
     name="Average Peak Occupancy per Hour"
     type="HOURLY_BREAKDOWN"
-    otherSettings={averagePeakOccupancyPerHourOtherSettings}
+    otherSettings={props.timeSegmentLabel === DEFAULT_TIME_SEGMENT_LABEL ?
+      averagePeakOccupancyPerHourOtherSettingsTimeSegmentNotSelected :
+      averagePeakOccupancyPerHourOtherSettingsTimeSegmentSelected}
     {...props}
   />;
 }


### PR DESCRIPTION
This updates the "hourly breakdown" and "periodic metrics" reports so they are compatible with time segments that go "overnight".