### PR TITLE
SpacesLegacyStore and spaces-legacy action types

### DIFF
--- a/src/components/admin-locations-edit/index.tsx
+++ b/src/components/admin-locations-edit/index.tsx
@@ -10,7 +10,7 @@ import spaceManagementFormDoorwayUpdate from '../../rx-actions/space-management/
 
 import colorVariables from '@density/ui/variables/colors.json';
 import { CoreSpace, CoreSpaceHierarchyNode } from '@density/lib-api-types/core-v2/spaces';
-import SpaceManagementStore, { AdminLocationsFormState, convertFormStateToSpaceFields, SpaceManagementState } from '../../rx-stores/space-management';
+import SpaceManagementStore, { AdminLocationsFormState, convertFormStateToSpaceFields, SpaceManagementState, AdminLocationsSpaceFieldUpdate } from '../../rx-stores/space-management';
 
 import {
   AdminLocationsDetailModulesGeneralInfo,
@@ -406,7 +406,7 @@ const ConnectedAdminLocationsEdit = () => {
 
   const selectedSpace = spaceManagement.spaces.data.find(s => s.id === spaceManagement.spaces.selected)
 
-  const onSave = async (space_id, spaceFieldUpdate) => {
+  const onSave = async (space_id: string, spaceFieldUpdate: AdminLocationsSpaceFieldUpdate) => {
     const ok = await collectionSpacesUpdate(dispatch, {
       ...spaceFieldUpdate,
       id: space_id,

--- a/src/components/admin-locations-edit/index.tsx
+++ b/src/components/admin-locations-edit/index.tsx
@@ -10,7 +10,7 @@ import spaceManagementFormDoorwayUpdate from '../../rx-actions/space-management/
 
 import colorVariables from '@density/ui/variables/colors.json';
 import { CoreSpace, CoreSpaceHierarchyNode } from '@density/lib-api-types/core-v2/spaces';
-import SpaceManagementStore, { AdminLocationsFormState, convertFormStateToSpaceFields, SpaceManagementState, AdminLocationsSpaceFieldUpdate } from '../../rx-stores/space-management';
+import SpaceManagementStore, { AdminLocationsFormState, convertFormStateToSpaceFields, SpaceManagementState, AdminLocationsSpaceFormResult } from '../../rx-stores/space-management';
 
 import {
   AdminLocationsDetailModulesGeneralInfo,
@@ -406,7 +406,7 @@ const ConnectedAdminLocationsEdit = () => {
 
   const selectedSpace = spaceManagement.spaces.data.find(s => s.id === spaceManagement.spaces.selected)
 
-  const onSave = async (space_id: string, spaceFieldUpdate: AdminLocationsSpaceFieldUpdate) => {
+  const onSave = async (space_id: string, spaceFieldUpdate: AdminLocationsSpaceFormResult) => {
     const ok = await collectionSpacesUpdate(dispatch, {
       ...spaceFieldUpdate,
       id: space_id,

--- a/src/components/admin-locations-root-detail/index.tsx
+++ b/src/components/admin-locations-root-detail/index.tsx
@@ -20,7 +20,15 @@ import { SpacesLegacyState } from '../../rx-stores/spaces-legacy';
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 
 
-function SpaceList({ user, spaces, renderedSpaces }) {
+function SpaceList({
+  user,
+  spaces,
+  renderedSpaces,
+}: {
+  user: UserState,
+  spaces: SpacesLegacyState,
+  renderedSpaces: CoreSpace[],
+}) {
   return (
     <div className={styles.spaceList}>
       <ListView

--- a/src/components/live-space-list/index.tsx
+++ b/src/components/live-space-list/index.tsx
@@ -165,10 +165,10 @@ const ConnectedAutoRefreshedLiveSpaceList: React.FC = () => {
     await hideModal(dispatch);
   }
   const onSpaceSearch = (searchQuery: string) => {
-    dispatch(collectionSpacesFilter('search', searchQuery) as Any<FixInRefactor>);
+    dispatch(collectionSpacesFilter('search', searchQuery));
   }
   const onSpaceChangeParent = (parent_id: string) => {
-    dispatch(collectionSpacesFilter('parent', parent_id) as Any<FixInRefactor>);
+    dispatch(collectionSpacesFilter('parent', parent_id));
   }
 
   return (

--- a/src/helpers/space-time-utilities/index.ts
+++ b/src/helpers/space-time-utilities/index.ts
@@ -3,6 +3,7 @@ import moment from 'moment-timezone';
 import { getGoSlow } from '../../components/environment-switcher';
 import fetchAllObjects from '../fetch-all-objects';
 import { QueryInterval } from '../../types/analytics';
+import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 
 
 export function getBrowserLocalTimeZone() {
@@ -27,7 +28,7 @@ export function serializeMomentToDateString(dateInstance) {
 // ----------------------------------------------------------------------------
 // TIME-RELATED OPERATIONS
 // ----------------------------------------------------------------------------
-export function getCurrentLocalTimeAtSpace(space) {
+export function getCurrentLocalTimeAtSpace(space: CoreSpace) {
   return moment.utc().tz(space.time_zone);
 }
 
@@ -53,7 +54,7 @@ export function parseFromReactDates(momentInstance, space) {
   return momentInstance.tz(space.time_zone).startOf('day');
 }
 
-export function formatInISOTime(timestamp) {
+export function formatInISOTime(timestamp: moment.Moment) {
   return timestamp.utc().toISOString();
 }
 export function formatInISOTimeAtSpace(timestamp, space) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -99,6 +99,7 @@ import moment from 'moment-timezone';
 import SpacesStore, { SpacesState } from './rx-stores/spaces';
 import DoorwaysStore, { DoorwaysState } from './rx-stores/doorways';
 import { interval } from 'rxjs';
+import { SpacesLegacySpaceEvent } from './rx-stores/spaces-legacy';
 
 configureClients();
 
@@ -346,7 +347,7 @@ livePageEventSource.on('connected', async () => {
   const spaces = await fetchAllObjects<CoreSpace>('/spaces');
   rxDispatch(collectionSpacesSet(spaces));
 
-  const spaceEventSets: any = await Promise.all(spaces.map(space => {
+  const spaceEventSets = await Promise.all(spaces.map(space => {
     return fetchAllObjects<CoreSpaceEvent>(`/spaces/${space.id}/events`, {
       params: {
         start_time: formatInISOTime(getCurrentLocalTimeAtSpace(space).subtract(1, 'minute')),
@@ -361,8 +362,8 @@ livePageEventSource.on('connected', async () => {
       timestamp: i.timestamp
     }));
     return acc;
-  }, {});
-  (rxDispatch as Any<FixInReview>)(collectionSpacesBatchSetEvents(eventsAtSpaces));
+  }, {} as {[spaceId: string]: Array<SpacesLegacySpaceEvent>});
+  rxDispatch(collectionSpacesBatchSetEvents(eventsAtSpaces));
 });
 
 livePageEventSource.on('space', countChangeEvent => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -371,7 +371,7 @@ livePageEventSource.on('space', countChangeEvent => {
   // So we're sending out many "count changes" in the case of an OB1 reset
   let absoluteDelta = Math.abs(countChangeEvent.direction);
   while (absoluteDelta > 0) {
-    (rxDispatch as Any<FixInReview>)(collectionSpacesCountChange({
+    rxDispatch(collectionSpacesCountChange({
       id: countChangeEvent.space_id,
       timestamp: countChangeEvent.timestamp,
       countChange: countChangeEvent.direction > 0 ? 1 : -1,

--- a/src/rx-actions/collection/spaces-legacy/count-change.ts
+++ b/src/rx-actions/collection/spaces-legacy/count-change.ts
@@ -1,5 +1,13 @@
 export const COLLECTION_SPACES_COUNT_CHANGE = 'COLLECTION_SPACES_COUNT_CHANGE';
 
-export default function collectionSpacesCountChange({id, timestamp, countChange}) {
-  return { type: COLLECTION_SPACES_COUNT_CHANGE, id, timestamp, countChange };
+export default function collectionSpacesCountChange({
+  id,
+  timestamp,
+  countChange,
+}: {
+  id: string,
+  timestamp: string,
+  countChange: 1 | -1,
+}) {
+  return { type: COLLECTION_SPACES_COUNT_CHANGE, id, timestamp, countChange } as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/create.ts
+++ b/src/rx-actions/collection/spaces-legacy/create.ts
@@ -6,6 +6,9 @@ import core from '../../../client/core';
 import uploadMedia from '../../../helpers/media-files';
 import { showToast, hideToast } from '../../toasts';
 import formatTagName from '../../../helpers/format-tag-name/index';
+import { DispatchType } from '../../../types/rx-actions';
+import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
+import { AdminLocationsSpaceFormResult } from '../../../rx-stores/space-management';
 
 export const COLLECTION_SPACES_CREATE = 'COLLECTION_SPACES_CREATE';
 
@@ -20,13 +23,14 @@ function convertSecondsIntoTime(seconds) {
     .format('HH:mm:ss');
 }
 
-export default async function collectionSpacesCreate(dispatch, item) {
+export default async function collectionSpacesCreate(dispatch: DispatchType, item: AdminLocationsSpaceFormResult) {
   dispatch({ type: COLLECTION_SPACES_CREATE, item });
 
   try {
-    const response = await core().post('/spaces', {
+    const response = await core().post<CoreSpace>('/spaces', {
       name: item.name,
-      description: item.description,
+      // REVIEW: The "description" field does not seem to be in the form, commenting out for now
+      // description: item.description,
       parent_id: item.parent_id,
       space_type: item.space_type,
       'function': item['function'],
@@ -86,7 +90,7 @@ export default async function collectionSpacesCreate(dispatch, item) {
         response.data.image_url = upload.media[0].signedUrl;
       }
     } else {
-      response.data.image_url = item.newImageData;
+      response.data.image_url = item.newImageData ? item.newImageData : null;
     }
 
     // When saving the space, create any links that were configured or changed in the doorways

--- a/src/rx-actions/collection/spaces-legacy/delete.ts
+++ b/src/rx-actions/collection/spaces-legacy/delete.ts
@@ -1,5 +1,7 @@
+import { CoreSpace } from "@density/lib-api-types/core-v2/spaces";
+
 export const COLLECTION_SPACES_DELETE = 'COLLECTION_SPACES_DELETE';
 
-export default function collectionSpacesDelete(item) {
-  return { type: COLLECTION_SPACES_DELETE, item };
+export default function collectionSpacesDelete(item: CoreSpace) {
+  return { type: COLLECTION_SPACES_DELETE, item } as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/destroy.ts
+++ b/src/rx-actions/collection/spaces-legacy/destroy.ts
@@ -1,10 +1,12 @@
 import collectionSpacesDelete from './delete';
 import collectionSpacesError from './error';
 import core from '../../../client/core';
+import { DispatchType } from '../../../types/rx-actions';
+import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 
 export const COLLECTION_SPACES_DESTROY = 'COLLECTION_SPACES_DESTROY';
 
-export default async function collectionSpacesDestroy(dispatch, space) {
+export default async function collectionSpacesDestroy(dispatch: DispatchType, space: CoreSpace) {
   dispatch({ type: COLLECTION_SPACES_DESTROY, space });
 
   try {

--- a/src/rx-actions/collection/spaces-legacy/error.ts
+++ b/src/rx-actions/collection/spaces-legacy/error.ts
@@ -1,11 +1,9 @@
-import { CollectionSpacesError } from '../../../types/redux';
-
 export const COLLECTION_SPACES_ERROR = 'COLLECTION_SPACES_ERROR';
 
-export default function collectionSpacesError(error: Error | string): CollectionSpacesError {
+export default function collectionSpacesError(error: Error | string) {
   // Convert error objects to strings.
   if (error instanceof Error) {
     error = error.toString();
   }
-  return {type: COLLECTION_SPACES_ERROR, error};
+  return {type: COLLECTION_SPACES_ERROR, error} as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/error.ts
+++ b/src/rx-actions/collection/spaces-legacy/error.ts
@@ -1,7 +1,8 @@
 import { CollectionSpacesError } from '../../../types/redux';
+
 export const COLLECTION_SPACES_ERROR = 'COLLECTION_SPACES_ERROR';
 
-export default function collectionSpacesError(error): CollectionSpacesError {
+export default function collectionSpacesError(error: Error | string): CollectionSpacesError {
   // Convert error objects to strings.
   if (error instanceof Error) {
     error = error.toString();

--- a/src/rx-actions/collection/spaces-legacy/fetch-all.ts
+++ b/src/rx-actions/collection/spaces-legacy/fetch-all.ts
@@ -3,12 +3,13 @@ import fetchAllObjects from '../../../helpers/fetch-all-objects';
 
 import collectionSpacesError from './error';
 import collectionSpacesSet from './set';
+import { DispatchType } from '../../../types/rx-actions';
 
 export const COLLECTION_SPACES_FETCH_ALL_START = 'COLLECTION_SPACES_FETCH_ALL_START';
 
-export default async function collectionSpacesFetchAll(dispatch) {
+export default async function collectionSpacesFetchAll(dispatch: DispatchType) {
   dispatch({ type: COLLECTION_SPACES_FETCH_ALL_START });
-  let spaces;
+  let spaces: Array<CoreSpace>;
   try {
     spaces = await fetchAllObjects<CoreSpace>('/spaces');
   } catch (err) {

--- a/src/rx-actions/collection/spaces-legacy/filter.ts
+++ b/src/rx-actions/collection/spaces-legacy/filter.ts
@@ -1,5 +1,5 @@
 export const COLLECTION_SPACES_FILTER = 'COLLECTION_SPACES_FILTER';
 
-export default function collectionSpacesFilter(filter, value) {
-  return { type: COLLECTION_SPACES_FILTER, filter, value };
+export default function collectionSpacesFilter(filter: 'search' | 'parent', value: string) {
+  return { type: COLLECTION_SPACES_FILTER, filter, value } as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/push.ts
+++ b/src/rx-actions/collection/spaces-legacy/push.ts
@@ -2,6 +2,6 @@ import { CoreSpace } from "@density/lib-api-types/core-v2/spaces";
 
 export const COLLECTION_SPACES_PUSH = 'COLLECTION_SPACES_PUSH';
 
-export default function collectionSpacesPush(item: CoreSpace) {
+export default function collectionSpacesPush(item: Partial<CoreSpace>) {
   return { type: COLLECTION_SPACES_PUSH, item } as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/push.ts
+++ b/src/rx-actions/collection/spaces-legacy/push.ts
@@ -1,5 +1,7 @@
+import { CoreSpace } from "@density/lib-api-types/core-v2/spaces";
+
 export const COLLECTION_SPACES_PUSH = 'COLLECTION_SPACES_PUSH';
 
-export default function collectionSpacesPush(item) {
-  return { type: COLLECTION_SPACES_PUSH, item };
+export default function collectionSpacesPush(item: CoreSpace) {
+  return { type: COLLECTION_SPACES_PUSH, item } as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/reset-count.ts
+++ b/src/rx-actions/collection/spaces-legacy/reset-count.ts
@@ -6,10 +6,12 @@ import {
   getCurrentLocalTimeAtSpace,
   formatInISOTime,
 } from '../../../helpers/space-time-utilities/index';
+import { DispatchType } from '../../../types/rx-actions';
+import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 
 export const COLLECTION_SPACES_RESET_COUNT = 'COLLECTION_SPACES_RESET_COUNT';
 
-export default async function collectionSpacesResetCount(dispatch, space, newCount) {
+export default async function collectionSpacesResetCount(dispatch: DispatchType, space: CoreSpace, newCount: number) {
   dispatch({ type: COLLECTION_SPACES_RESET_COUNT, item: space, newCount });
 
   try {

--- a/src/rx-actions/collection/spaces-legacy/set-default-time-range.ts
+++ b/src/rx-actions/collection/spaces-legacy/set-default-time-range.ts
@@ -2,6 +2,6 @@ import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 
 export const COLLECTION_SPACES_SET_DEFAULT_TIME_RANGE = 'COLLECTION_SPACES_SET_DEFAULT_TIME_RANGE';
 
-export default function collectionSpacesSetDefaultTimeRange(space: CoreSpace | undefined) {
-  return { type: COLLECTION_SPACES_SET_DEFAULT_TIME_RANGE, space };
+export default function collectionSpacesSetDefaultTimeRange(space: CoreSpace) {
+  return { type: COLLECTION_SPACES_SET_DEFAULT_TIME_RANGE, space } as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/set-events.ts
+++ b/src/rx-actions/collection/spaces-legacy/set-events.ts
@@ -1,10 +1,16 @@
+import { CoreSpace } from "@density/lib-api-types/core-v2/spaces";
+import { SpacesLegacySpaceEvent } from "../../../rx-stores/spaces-legacy";
+
 export const COLLECTION_SPACES_SET_EVENTS = 'COLLECTION_SPACES_SET_EVENTS';
 export const COLLECTION_SPACES_BATCH_SET_EVENTS = 'COLLECTION_SPACES_BATCH_SET_EVENTS';
 
-export default function collectionSpacesSetEvents(item, events) {
-  return { type: COLLECTION_SPACES_SET_EVENTS, item, events };
+export default function collectionSpacesSetEvents(item: CoreSpace, events: Array<SpacesLegacySpaceEvent>) {
+  return { type: COLLECTION_SPACES_SET_EVENTS, item, events } as const;
 }
 
-export function collectionSpacesBatchSetEvents(events) {
-  return { type: COLLECTION_SPACES_BATCH_SET_EVENTS, events };
+type SpaceEventsBySpaceId = {
+  [spaceId: string]: Array<SpacesLegacySpaceEvent>
+}
+export function collectionSpacesBatchSetEvents(events: SpaceEventsBySpaceId) {
+  return { type: COLLECTION_SPACES_BATCH_SET_EVENTS, events } as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/set.ts
+++ b/src/rx-actions/collection/spaces-legacy/set.ts
@@ -1,6 +1,8 @@
 import { CollectionSpacesSet } from '../../../types/redux';
+import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
+
 export const COLLECTION_SPACES_SET = 'COLLECTION_SPACES_SET';
 
-export default function collectionSpacesSet(spaces): CollectionSpacesSet {
+export default function collectionSpacesSet(spaces: Array<CoreSpace>): CollectionSpacesSet {
   return { type: COLLECTION_SPACES_SET, data: spaces };
 }

--- a/src/rx-actions/collection/spaces-legacy/set.ts
+++ b/src/rx-actions/collection/spaces-legacy/set.ts
@@ -1,8 +1,7 @@
-import { CollectionSpacesSet } from '../../../types/redux';
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 
 export const COLLECTION_SPACES_SET = 'COLLECTION_SPACES_SET';
 
-export default function collectionSpacesSet(spaces: Array<CoreSpace>): CollectionSpacesSet {
-  return { type: COLLECTION_SPACES_SET, data: spaces };
+export default function collectionSpacesSet(spaces: Array<CoreSpace>) {
+  return { type: COLLECTION_SPACES_SET, data: spaces } as const;
 }

--- a/src/rx-actions/collection/spaces-legacy/update.ts
+++ b/src/rx-actions/collection/spaces-legacy/update.ts
@@ -9,6 +9,8 @@ import collectionSpacesError from './error';
 import core from '../../../client/core';
 import uploadMedia from '../../../helpers/media-files';
 import { showToast, hideToast } from '../../toasts';
+import { DispatchType } from '../../../types/rx-actions';
+import { AdminLocationsSpaceFieldUpdate } from '../../../rx-stores/space-management';
 
 export const COLLECTION_SPACES_UPDATE = 'COLLECTION_SPACES_UPDATE';
 
@@ -23,13 +25,14 @@ function convertSecondsIntoTime(seconds) {
     .format('HH:mm:ss');
 }
 
-export default async function collectionSpacesUpdate(dispatch, item) {
+export default async function collectionSpacesUpdate(dispatch: DispatchType, item: AdminLocationsSpaceFieldUpdate) {
   dispatch({ type: COLLECTION_SPACES_UPDATE, item });
 
   try {
     await core().put(`/spaces/${item.id}`, {
       name: item.name,
-      description: item.description,
+      // REVIEW: this field does not seem to exist in the forms, commenting out for now
+      //description: item.description,
       parent_id: item.parent_id,
       space_type: item.space_type,
       'function': item['function'],

--- a/src/rx-actions/collection/spaces-legacy/update.ts
+++ b/src/rx-actions/collection/spaces-legacy/update.ts
@@ -10,7 +10,7 @@ import core from '../../../client/core';
 import uploadMedia from '../../../helpers/media-files';
 import { showToast, hideToast } from '../../toasts';
 import { DispatchType } from '../../../types/rx-actions';
-import { AdminLocationsSpaceFieldUpdate } from '../../../rx-stores/space-management';
+import { AdminLocationsSpaceFormResult } from '../../../rx-stores/space-management';
 
 export const COLLECTION_SPACES_UPDATE = 'COLLECTION_SPACES_UPDATE';
 
@@ -25,7 +25,7 @@ function convertSecondsIntoTime(seconds) {
     .format('HH:mm:ss');
 }
 
-export default async function collectionSpacesUpdate(dispatch: DispatchType, item: AdminLocationsSpaceFieldUpdate) {
+export default async function collectionSpacesUpdate(dispatch: DispatchType, item: AdminLocationsSpaceFormResult) {
   dispatch({ type: COLLECTION_SPACES_UPDATE, item });
 
   try {

--- a/src/rx-actions/route-transition/live-space-detail.ts
+++ b/src/rx-actions/route-transition/live-space-detail.ts
@@ -10,6 +10,7 @@ import {
   formatInISOTime,
 } from '../../helpers/space-time-utilities/index';
 import fetchAllObjects, { fetchObject } from '../../helpers/fetch-all-objects';
+import { CoreSpaceEvent } from '@density/lib-api-types/core-v2/events';
 
 export const ROUTE_TRANSITION_LIVE_SPACE_DETAIL = 'ROUTE_TRANSITION_LIVE_SPACE_DETAIL';
 
@@ -23,7 +24,7 @@ export default async function routeTransitionLiveSpaceDetail(dispatch, id) {
     // Fetch all initial events for the space that was loaded.
     // This is used to populate this space's events collection with all the events from the last
     // minute so that the real time event charts all display as "full" when the page reloads.
-    const spaceEventSet = await fetchAllObjects(`/spaces/${space.id}/events`, {
+    const spaceEventSet = await fetchAllObjects<CoreSpaceEvent>(`/spaces/${space.id}/events`, {
       cache: false,
       params: {
         id: space.id,

--- a/src/rx-actions/route-transition/live-space-list.ts
+++ b/src/rx-actions/route-transition/live-space-list.ts
@@ -8,17 +8,20 @@ import {
 
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 import fetchAllObjects from '../../helpers/fetch-all-objects';
+import { CoreSpaceEvent } from '@density/lib-api-types/core-v2/events';
+import { SpacesLegacySpaceEvent } from '../../rx-stores/spaces-legacy';
+import { DispatchType } from '../../types/rx-actions';
 
 export const ROUTE_TRANSITION_LIVE_SPACE_LIST = 'ROUTE_TRANSITION_LIVE_SPACE_LIST';
 
-export default async function routeTransitionLiveSpaceList(dispatch) {
-  dispatch({ type: ROUTE_TRANSITION_LIVE_SPACE_LIST });
+export default async function routeTransitionLiveSpaceList(dispatch: DispatchType) {
+  dispatch({ type: ROUTE_TRANSITION_LIVE_SPACE_LIST } as Any<FixInRefactor>);
 
   const spaces = await fetchAllObjects<CoreSpace>('/spaces');
   dispatch(collectionSpacesSet(spaces));
 
-  const spaceEventSets: any = await Promise.all(spaces.map(space => {
-    return fetchAllObjects(`/spaces/${space.id}/events`, {
+  const spaceEventSets = await Promise.all(spaces.map(space => {
+    return fetchAllObjects<CoreSpaceEvent>(`/spaces/${space.id}/events`, {
       cache: false,
       params: {
         start_time: formatInISOTime(getCurrentLocalTimeAtSpace(space).subtract(1, 'minute')),
@@ -33,7 +36,7 @@ export default async function routeTransitionLiveSpaceList(dispatch) {
       timestamp: i.timestamp
     }));
     return acc;
-  }, {});
+  }, {} as {[spaceId: string]: Array<SpacesLegacySpaceEvent>});
 
   dispatch(collectionSpacesBatchSetEvents(eventsAtSpaces));
 }

--- a/src/rx-stores/analytics/effects.ts
+++ b/src/rx-stores/analytics/effects.ts
@@ -243,7 +243,7 @@ export function registerRouteTransitionEffects(
         return fetchAllObjects<CoreSpace>('/spaces');
       }
     }),
-    map(spaces => collectionSpacesSet(spaces)),
+    map(spaces => collectionSpacesSet(spaces as Array<CoreSpace>)),
   );
 
   const spaceHierarchyLoadStream = routeTransitionStream.pipe(

--- a/src/rx-stores/analytics/effects.ts
+++ b/src/rx-stores/analytics/effects.ts
@@ -228,7 +228,7 @@ export function registerRouteTransitionEffects(
     )),
   );
 
-  const whileInitialDataNotPopulated = () => source => source.pipe(
+  const whileInitialDataNotPopulated = () => (source: typeof routeTransitionStream) => source.pipe(
     filter(([spacesState, spaceHierarchyState, analyticsState]) => (
       analyticsState.status !== ResourceStatus.COMPLETE
     )),

--- a/src/rx-stores/space-management/index.ts
+++ b/src/rx-stores/space-management/index.ts
@@ -97,6 +97,7 @@ export type AdminLocationsFormState = {
   overrideDefault: boolean,
   overrideDefaultControlHidden: boolean,
   image_url: string,
+  newImageData?: string,
   newImageFile?: any,
   tags?: Array<{
     name: string,
@@ -275,7 +276,7 @@ function calculateInitialFormState({
   };
 }
 
-export type AdminLocationsSpaceFieldUpdate = ReturnType<typeof convertFormStateToSpaceFields> & {
+export type AdminLocationsSpaceFormResult = ReturnType<typeof convertFormStateToSpaceFields> & {
   id: string,
 }
 
@@ -317,6 +318,7 @@ export function convertFormStateToSpaceFields(
     daily_reset: formState.daily_reset,
     time_zone: formState.time_zone,
 
+    newImageData: formState.newImageData,
     newImageFile: formState.newImageFile,
     operatingHours: formState.operatingHours,
 

--- a/src/rx-stores/space-management/index.ts
+++ b/src/rx-stores/space-management/index.ts
@@ -275,12 +275,16 @@ function calculateInitialFormState({
   };
 }
 
+export type AdminLocationsSpaceFieldUpdate = ReturnType<typeof convertFormStateToSpaceFields> & {
+  id: string,
+}
+
 // Given the state of the form, convert that state back into fields that can be sent in the body of
 // a PUT to the space.
 export function convertFormStateToSpaceFields(
   formState: AdminLocationsFormState,
   space_type: CoreSpace["space_type"],
-): object {
+) {
   function parseIntOrNull(string) {
     const result = parseInt(string, 10);
     if (isNaN(result)) {

--- a/src/rx-stores/spaces-legacy/index.test.ts
+++ b/src/rx-stores/spaces-legacy/index.test.ts
@@ -7,23 +7,20 @@ import collectionSpacesFilter from '../../rx-actions/collection/spaces-legacy/fi
 import collectionSpacesDelete from '../../rx-actions/collection/spaces-legacy/delete';
 import collectionSpacesError from '../../rx-actions/collection/spaces-legacy/error';
 import { COLLECTION_SPACES_UPDATE } from '../../rx-actions/collection/spaces-legacy/update'; 
+import { createSpace } from '../../helpers/test-utilities/objects/space';
 
 describe('spaces', function() {
   it('should set spaces when given a bunch of spaces', function() {
     const result = spacesLegacyReducer(initialState, collectionSpacesSet([
-      {id: '0', name: 'foo', current_count: 5},
-      {id: '1', name: 'bar', current_count: 8},
+      createSpace({id: '0', name: 'foo', current_count: 5}),
+      createSpace({id: '1', name: 'bar', current_count: 8}),
     ]));
 
-    assert.deepEqual(result, {
-      ...initialState,
-      view: 'VISIBLE',
-      loading: false,
-      data: [
-        {id: '0', name: 'foo', current_count: 5},
-        {id: '1', name: 'bar', current_count: 8},
-      ],
-    });
+    expect(result.view).toEqual('VISIBLE')
+    expect(result.loading).toEqual(false)
+    expect(result.data.length).toEqual(2)
+    expect(result.data[0]).toMatchObject({id: '0', name: 'foo', current_count: 5})
+    expect(result.data[1]).toMatchObject({id: '1', name: 'bar', current_count: 8})
   });
   it('should push space when given a space update', function() {
     // Add a new space.
@@ -97,13 +94,13 @@ describe('spaces', function() {
     const state = spacesLegacyReducer(errorState, {type: COLLECTION_SPACES_UPDATE});
 
     // Initial state should then have error: null
-    assert.deepEqual(state, {...initialState, error: null, loading: true});
+    expect(state.error).toEqual(null)
   });
   it('should clear the parent space filter on set if the parent space was deleted', function() {
     // Set two spaces
     const resulta = spacesLegacyReducer(initialState, collectionSpacesSet([
-      {id: '0', name: 'foo', current_count: 5},
-      {id: '1', name: 'bar', current_count: 8},
+      createSpace({id: '0', name: 'foo', current_count: 5}),
+      createSpace({id: '1', name: 'bar', current_count: 8}),
     ]));
 
     // Set the selected parent space equal to one of those spaces
@@ -111,7 +108,7 @@ describe('spaces', function() {
 
     // Set one space
     const resultb = spacesLegacyReducer(resulta, collectionSpacesSet([
-      {id: '0', name: 'foo', current_count: 5},
+      createSpace({id: '0', name: 'foo', current_count: 5}),
     ]));
 
     // Ensure that the parent filter has been cleared, since the space that was in there no longer

--- a/src/rx-stores/spaces-legacy/index.test.ts
+++ b/src/rx-stores/spaces-legacy/index.test.ts
@@ -24,11 +24,12 @@ describe('spaces', function() {
   });
   it('should push space when given a space update', function() {
     // Add a new space.
-    const spaceInCollection = spacesLegacyReducer(initialState, collectionSpacesPush({
+    const newSpace = createSpace({
       id: '0',
       name: 'foo',
       current_count: 4,
-    }));
+    })
+    const spaceInCollection = spacesLegacyReducer(initialState, collectionSpacesPush(newSpace));
 
     // Update space in collection
     const spaceUpdatedInCollection = spacesLegacyReducer(spaceInCollection, collectionSpacesPush({
@@ -36,12 +37,10 @@ describe('spaces', function() {
       name: 'new name',
     }));
 
-    assert.deepEqual(spaceUpdatedInCollection, {
-      ...initialState,
-      view: 'VISIBLE',
-      loading: false,
-      data: [{id: 0, name: 'new name', current_count: 4}],
-    });
+    expect(spaceUpdatedInCollection.view).toEqual('VISIBLE')
+    expect(spaceUpdatedInCollection.loading).toEqual(false)
+    expect(spaceUpdatedInCollection.data.length).toEqual(1)
+    expect(spaceUpdatedInCollection.data[0]).toMatchObject({id: '0', name: 'new name', current_count: 4})
   });
   it('should push space when given a new space', function() {
     const result = spacesLegacyReducer(initialState, collectionSpacesPush({
@@ -66,11 +65,11 @@ describe('spaces', function() {
     });
   });
   it('should delete a space from the spaces collection', function() {
-    const SPACE = {
+    const SPACE = createSpace({
       id: '0',
       name: 'foo',
       current_count: 5,
-    };
+    });
 
     // Add a space, then delete a space
     const spaceInCollection = spacesLegacyReducer(initialState, collectionSpacesPush(SPACE));

--- a/src/rx-stores/spaces-legacy/index.test.ts
+++ b/src/rx-stores/spaces-legacy/index.test.ts
@@ -11,8 +11,8 @@ import { COLLECTION_SPACES_UPDATE } from '../../rx-actions/collection/spaces-leg
 describe('spaces', function() {
   it('should set spaces when given a bunch of spaces', function() {
     const result = spacesLegacyReducer(initialState, collectionSpacesSet([
-      {id: 0, name: 'foo', current_count: 5},
-      {id: 1, name: 'bar', current_count: 8},
+      {id: '0', name: 'foo', current_count: 5},
+      {id: '1', name: 'bar', current_count: 8},
     ]));
 
     assert.deepEqual(result, {
@@ -20,22 +20,22 @@ describe('spaces', function() {
       view: 'VISIBLE',
       loading: false,
       data: [
-        {id: 0, name: 'foo', current_count: 5},
-        {id: 1, name: 'bar', current_count: 8},
+        {id: '0', name: 'foo', current_count: 5},
+        {id: '1', name: 'bar', current_count: 8},
       ],
     });
   });
   it('should push space when given a space update', function() {
     // Add a new space.
     const spaceInCollection = spacesLegacyReducer(initialState, collectionSpacesPush({
-      id: 0,
+      id: '0',
       name: 'foo',
       current_count: 4,
     }));
 
     // Update space in collection
     const spaceUpdatedInCollection = spacesLegacyReducer(spaceInCollection, collectionSpacesPush({
-      id: 0,
+      id: '0',
       name: 'new name',
     }));
 
@@ -48,7 +48,7 @@ describe('spaces', function() {
   });
   it('should push space when given a new space', function() {
     const result = spacesLegacyReducer(initialState, collectionSpacesPush({
-      id: 0,
+      id: '0',
       name: 'foo',
       current_count: 5,
     }));
@@ -57,7 +57,7 @@ describe('spaces', function() {
       ...initialState,
       view: 'VISIBLE',
       loading: false,
-      data: [{id: 0, name: 'foo', current_count: 5}],
+      data: [{id: '0', name: 'foo', current_count: 5}],
     });
   });
   it('should filter space collection when given a filter', function() {
@@ -70,7 +70,7 @@ describe('spaces', function() {
   });
   it('should delete a space from the spaces collection', function() {
     const SPACE = {
-      id: 0,
+      id: '0',
       name: 'foo',
       current_count: 5,
     };
@@ -102,16 +102,16 @@ describe('spaces', function() {
   it('should clear the parent space filter on set if the parent space was deleted', function() {
     // Set two spaces
     const resulta = spacesLegacyReducer(initialState, collectionSpacesSet([
-      {id: 0, name: 'foo', current_count: 5},
-      {id: 1, name: 'bar', current_count: 8},
+      {id: '0', name: 'foo', current_count: 5},
+      {id: '1', name: 'bar', current_count: 8},
     ]));
 
     // Set the selected parent space equal to one of those spaces
-    initialState.filters.parent = 1;
+    initialState.filters.parent = '1';
 
     // Set one space
     const resultb = spacesLegacyReducer(resulta, collectionSpacesSet([
-      {id: 0, name: 'foo', current_count: 5},
+      {id: '0', name: 'foo', current_count: 5},
     ]));
 
     // Ensure that the parent filter has been cleared, since the space that was in there no longer

--- a/src/rx-stores/spaces-legacy/index.ts
+++ b/src/rx-stores/spaces-legacy/index.ts
@@ -22,7 +22,7 @@ import { ROUTE_TRANSITION_LIVE_SPACE_DETAIL } from '../../rx-actions/route-trans
 import { ROUTE_TRANSITION_ADMIN_LOCATIONS } from '../../rx-actions/route-transition/admin-locations';
 import { ROUTE_TRANSITION_ADMIN_LOCATIONS_NEW } from '../../rx-actions/route-transition/admin-locations-new';
 import { ROUTE_TRANSITION_ADMIN_LOCATIONS_EDIT } from '../../rx-actions/route-transition/admin-locations-edit';
-import { SORT_A_Z } from '../../helpers/sort-collection/index';
+import { SORT_A_Z, SORT_NEWEST } from '../../helpers/sort-collection/index';
 import { SHOW_MODAL } from '../../rx-actions/modal/show';
 import { HIDE_MODAL } from '../../rx-actions/modal/hide';
 
@@ -34,11 +34,6 @@ import createRxStore from '..';
 // Store at maximum 500 events per space
 const EVENT_QUEUE_LENGTH = 500;
 
-// How long should data be fetched when running utilization calculations?
-const DATA_DURATION_WEEK = 'DATA_DURATION_WEEK';
-      // DATA_DURATION_MONTH = 'DATA_DURATION_MONTH';
-
-
 export type SpacesLegacyState = {
   view: 'LOADING' | 'VISIBLE' | 'ERROR',
   data: CoreSpace[],
@@ -46,21 +41,19 @@ export type SpacesLegacyState = {
   error: unknown,
   selected: CoreSpace['id'] | null,
   filters: {
-    doorway_id: Any<FixInRefactor>,
+    doorway_id: string | null,
     search: string,
-    sort: Any<FixInRefactor>,
-    parent: Any<FixInRefactor>,
-    timeSegmentLabel: Any<FixInRefactor>,
-    dataDuration: Any<FixInRefactor>,
-    metricToDisplay: Any<FixInRefactor>,
-    dailyRawEventsPage: number,
-
-    startDate: Any<FixInRefactor>,
-    endDate: Any<FixInRefactor>,
-    date: Any<FixInRefactor>,
+    parent: string | null,
+    timeSegmentLabel: string,
+    startDate: string | null,
+    endDate: string | null,
+    date: string | null,
   },
   events: {
-    [space_id: string]: Any<FixInRefactor>[]
+    [space_id: string]: Array<{
+      timestamp: string,
+      countChange: number,
+    }>
   }
 }
 
@@ -73,14 +66,8 @@ export const initialState: SpacesLegacyState = {
   filters: {
     doorway_id: null,
     search: '',
-    sort: SORT_A_Z,
     parent: null,
-
     timeSegmentLabel: DEFAULT_TIME_SEGMENT_LABEL,
-    dataDuration: DATA_DURATION_WEEK,
-
-    metricToDisplay: 'entrances',
-    dailyRawEventsPage: 1,
 
     // Used for date ranges
     startDate: null,
@@ -93,7 +80,7 @@ export const initialState: SpacesLegacyState = {
   // An object that maps space id to an array of events
   events: {
     /* For example:
-    'spc_XXXX': [{timestamp: '2017-07-24T12:37:42.946Z', direction: 1}],
+    'spc_XXXX': [{timestamp: '2017-07-24T12:37:42.946Z', countChange: 1}],
     */
   },
 };

--- a/src/rx-stores/spaces-legacy/index.ts
+++ b/src/rx-stores/spaces-legacy/index.ts
@@ -22,7 +22,6 @@ import { ROUTE_TRANSITION_LIVE_SPACE_DETAIL } from '../../rx-actions/route-trans
 import { ROUTE_TRANSITION_ADMIN_LOCATIONS } from '../../rx-actions/route-transition/admin-locations';
 import { ROUTE_TRANSITION_ADMIN_LOCATIONS_NEW } from '../../rx-actions/route-transition/admin-locations-new';
 import { ROUTE_TRANSITION_ADMIN_LOCATIONS_EDIT } from '../../rx-actions/route-transition/admin-locations-edit';
-import { SORT_A_Z, SORT_NEWEST } from '../../helpers/sort-collection/index';
 import { SHOW_MODAL } from '../../rx-actions/modal/show';
 import { HIDE_MODAL } from '../../rx-actions/modal/hide';
 

--- a/src/rx-stores/spaces-legacy/index.ts
+++ b/src/rx-stores/spaces-legacy/index.ts
@@ -33,6 +33,11 @@ import createRxStore from '..';
 // Store at maximum 500 events per space
 const EVENT_QUEUE_LENGTH = 500;
 
+export type SpacesLegacySpaceEvent = {
+  timestamp: string,
+  countChange: number,
+}
+
 export type SpacesLegacyState = {
   view: 'LOADING' | 'VISIBLE' | 'ERROR',
   data: CoreSpace[],
@@ -49,10 +54,7 @@ export type SpacesLegacyState = {
     date: string | null,
   },
   events: {
-    [space_id: string]: Array<{
-      timestamp: string,
-      countChange: number,
-    }>
+    [space_id: string]: Array<SpacesLegacySpaceEvent>
   }
 }
 

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -1,21 +1,22 @@
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
-// import { COLLECTION_SPACES_SET } from '../actions/collection/spaces/set';
-// import { COLLECTION_SPACES_ERROR } from '../actions/collection/spaces/error';
+import { COLLECTION_SPACES_SET } from '../rx-actions/collection/spaces-legacy/set';
+import { COLLECTION_SPACES_ERROR } from '../rx-actions/collection/spaces-legacy/error';
+import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
+import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
+import { TRANSITION_TO_HIDE_MODAL, HIDE_MODAL } from '../rx-actions/modal/hide';
+import { UPDATE_MODAL } from '../rx-actions/modal/update';
 
-// FIXME: The below 'COLLECTION_SPACES_SET' and 'COLLECTION_SPACES_ERROR' should use the constants
-// imported above, but if I do that, it types it as `string` and not the constant string it is set
-// to. Please point this point in a review!
-export type CollectionSpacesSet = { type: 'COLLECTION_SPACES_SET', data: Array<CoreSpace> };
-export type CollectionSpacesError = { type: 'COLLECTION_SPACES_ERROR', error: Error | string };
-export type CollectionSpaceHierarchySet = { type: 'COLLECTION_SPACE_HIERARCHY_SET', data: Array<CoreSpace> };
+export type CollectionSpacesSet = { type: typeof COLLECTION_SPACES_SET, data: Array<CoreSpace> };
+export type CollectionSpacesError = { type: typeof COLLECTION_SPACES_ERROR, error: Error | string };
+export type CollectionSpaceHierarchySet = { type: typeof COLLECTION_SPACE_HIERARCHY_SET, data: Array<CoreSpace> };
 
-export type TransitionToShowModal = { type: 'TRANSITION_TO_SHOW_MODAL', name: string, data: object };
-export type ShowModal = { type: 'SHOW_MODAL' };
+export type TransitionToShowModal = { type: typeof TRANSITION_TO_SHOW_MODAL, name: string, data: object };
+export type ShowModal = { type: typeof SHOW_MODAL };
 
-export type TransitionToHideModal = { type: 'TRANSITION_TO_HIDE_MODAL', name: string, data: object };
-export type HideModal = { type: 'HIDE_MODAL' };
+export type TransitionToHideModal = { type: typeof TRANSITION_TO_HIDE_MODAL, name: string, data: object };
+export type HideModal = { type: typeof HIDE_MODAL };
 
-export type UpdateModal = { type: 'UPDATE_MODAL' };
+export type UpdateModal = { type: typeof UPDATE_MODAL };
 
 export type ReduxAction = (
   CollectionSpacesSet |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -9,6 +9,7 @@ import collectionSpacesSetEvents, { collectionSpacesBatchSetEvents } from '../rx
 import collectionSpacesSetDefaultTimeRange from '../rx-actions/collection/spaces-legacy/set-default-time-range';
 import { COLLECTION_SPACES_CREATE } from '../rx-actions/collection/spaces-legacy/create';
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
+import { COLLECTION_SPACES_RESET_COUNT } from '../rx-actions/collection/spaces-legacy/reset-count';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
 import { TRANSITION_TO_HIDE_MODAL, HIDE_MODAL } from '../rx-actions/modal/hide';
@@ -27,6 +28,7 @@ export type CollectionSpacesBatchSetEvents = ReturnType<typeof collectionSpacesB
 
 export type CollectionSpacesCreate = { type: typeof COLLECTION_SPACES_CREATE, item: AdminLocationsSpaceFormResult };
 export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFormResult };
+export type CollectionSpacesResetCount = { type: typeof COLLECTION_SPACES_RESET_COUNT, item: CoreSpace, newCount: number };
 
 export type CollectionSpaceHierarchySet = { type: typeof COLLECTION_SPACE_HIERARCHY_SET, data: Array<CoreSpace> };
 
@@ -44,6 +46,7 @@ export type ReduxAction = (
   CollectionSpacesError |
   CollectionSpacesFilter |
   CollectionSpacesPush |
+  CollectionSpacesResetCount |
   CollectionSpacesSet |
   CollectionSpacesSetDefaultTimeRange |
   CollectionSpacesSetEvents |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -1,6 +1,6 @@
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 import collectionSpacesSet from '../rx-actions/collection/spaces-legacy/set';
-import collectionSpacesDelete, { COLLECTION_SPACES_DELETE } from '../rx-actions/collection/spaces-legacy/delete';
+import collectionSpacesDelete from '../rx-actions/collection/spaces-legacy/delete';
 import collectionSpacesError from '../rx-actions/collection/spaces-legacy/error';
 import collectionSpacesPush from '../rx-actions/collection/spaces-legacy/push';
 import collectionSpacesCountChange from '../rx-actions/collection/spaces-legacy/count-change';

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -1,13 +1,16 @@
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 import { COLLECTION_SPACES_SET } from '../rx-actions/collection/spaces-legacy/set';
 import { COLLECTION_SPACES_ERROR } from '../rx-actions/collection/spaces-legacy/error';
+import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
 import { TRANSITION_TO_HIDE_MODAL, HIDE_MODAL } from '../rx-actions/modal/hide';
 import { UPDATE_MODAL } from '../rx-actions/modal/update';
+import { AdminLocationsSpaceFieldUpdate } from '../rx-stores/space-management';
 
 export type CollectionSpacesSet = { type: typeof COLLECTION_SPACES_SET, data: Array<CoreSpace> };
 export type CollectionSpacesError = { type: typeof COLLECTION_SPACES_ERROR, error: Error | string };
+export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFieldUpdate }
 export type CollectionSpaceHierarchySet = { type: typeof COLLECTION_SPACE_HIERARCHY_SET, data: Array<CoreSpace> };
 
 export type TransitionToShowModal = { type: typeof TRANSITION_TO_SHOW_MODAL, name: string, data: object };
@@ -21,6 +24,7 @@ export type UpdateModal = { type: typeof UPDATE_MODAL };
 export type ReduxAction = (
   CollectionSpacesSet |
   CollectionSpacesError |
+  CollectionSpacesUpdate |
   CollectionSpaceHierarchySet |
   TransitionToShowModal |
   ShowModal |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -11,6 +11,7 @@ import { COLLECTION_SPACES_CREATE } from '../rx-actions/collection/spaces-legacy
 import { COLLECTION_SPACES_DESTROY } from '../rx-actions/collection/spaces-legacy/destroy';
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACES_RESET_COUNT } from '../rx-actions/collection/spaces-legacy/reset-count';
+import { COLLECTION_SPACES_FETCH_ALL_START } from '../rx-actions/collection/spaces-legacy/fetch-all';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
 import { TRANSITION_TO_HIDE_MODAL, HIDE_MODAL } from '../rx-actions/modal/hide';
@@ -31,6 +32,7 @@ export type CollectionSpacesCreate = { type: typeof COLLECTION_SPACES_CREATE, it
 export type CollectionSpacesDestroy = { type: typeof COLLECTION_SPACES_DESTROY, space: CoreSpace };
 export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFormResult };
 export type CollectionSpacesResetCount = { type: typeof COLLECTION_SPACES_RESET_COUNT, item: CoreSpace, newCount: number };
+export type CollectionSpacesFetchAllStart = { type: typeof COLLECTION_SPACES_FETCH_ALL_START };
 
 export type CollectionSpaceHierarchySet = { type: typeof COLLECTION_SPACE_HIERARCHY_SET, data: Array<CoreSpace> };
 
@@ -56,6 +58,7 @@ export type ReduxAction = (
   CollectionSpacesCreate |
   CollectionSpacesDestroy |
   CollectionSpacesUpdate |
+  CollectionSpacesFetchAllStart |
   CollectionSpaceHierarchySet |
   TransitionToShowModal |
   ShowModal |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -6,6 +6,7 @@ import { COLLECTION_SPACES_PUSH } from '../rx-actions/collection/spaces-legacy/p
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
 import collectionSpacesCountChange from '../rx-actions/collection/spaces-legacy/count-change';
+import collectionSpacesFilter from '../rx-actions/collection/spaces-legacy/filter';
 import collectionSpacesSetEvents, { collectionSpacesBatchSetEvents } from '../rx-actions/collection/spaces-legacy/set-events';
 import collectionSpacesSetDefaultTimeRange from '../rx-actions/collection/spaces-legacy/set-default-time-range';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
@@ -17,6 +18,7 @@ export type CollectionSpacesSet = { type: typeof COLLECTION_SPACES_SET, data: Ar
 export type CollectionSpacesCountChange = ReturnType<typeof collectionSpacesCountChange>;
 export type CollectionSpacesDelete = { type: typeof COLLECTION_SPACES_DELETE, item: CoreSpace };
 export type CollectionSpacesError = { type: typeof COLLECTION_SPACES_ERROR, error: Error | string };
+export type CollectionSpacesFilter = ReturnType<typeof collectionSpacesFilter>;
 export type CollectionSpacesPush = { type: typeof COLLECTION_SPACES_PUSH, item: CoreSpace };
 export type CollectionSpacesSetDefaultTimeRange = ReturnType<typeof collectionSpacesSetDefaultTimeRange>;
 export type CollectionSpacesSetEvents = ReturnType<typeof collectionSpacesSetEvents>;
@@ -37,6 +39,7 @@ export type ReduxAction = (
   CollectionSpacesCountChange |
   CollectionSpacesDelete |
   CollectionSpacesError |
+  CollectionSpacesFilter |
   CollectionSpacesPush |
   CollectionSpacesSetDefaultTimeRange |
   CollectionSpacesSetEvents |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -1,25 +1,25 @@
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
-import { COLLECTION_SPACES_SET } from '../rx-actions/collection/spaces-legacy/set';
-import { COLLECTION_SPACES_DELETE } from '../rx-actions/collection/spaces-legacy/delete';
-import { COLLECTION_SPACES_ERROR } from '../rx-actions/collection/spaces-legacy/error';
-import { COLLECTION_SPACES_PUSH } from '../rx-actions/collection/spaces-legacy/push';
-import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
-import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
+import collectionSpacesSet from '../rx-actions/collection/spaces-legacy/set';
+import collectionSpacesDelete from '../rx-actions/collection/spaces-legacy/delete';
+import collectionSpacesError from '../rx-actions/collection/spaces-legacy/error';
+import collectionSpacesPush from '../rx-actions/collection/spaces-legacy/push';
 import collectionSpacesCountChange from '../rx-actions/collection/spaces-legacy/count-change';
 import collectionSpacesFilter from '../rx-actions/collection/spaces-legacy/filter';
 import collectionSpacesSetEvents, { collectionSpacesBatchSetEvents } from '../rx-actions/collection/spaces-legacy/set-events';
 import collectionSpacesSetDefaultTimeRange from '../rx-actions/collection/spaces-legacy/set-default-time-range';
+import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
+import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
 import { TRANSITION_TO_HIDE_MODAL, HIDE_MODAL } from '../rx-actions/modal/hide';
 import { UPDATE_MODAL } from '../rx-actions/modal/update';
 import { AdminLocationsSpaceFieldUpdate } from '../rx-stores/space-management';
 
-export type CollectionSpacesSet = { type: typeof COLLECTION_SPACES_SET, data: Array<CoreSpace> };
 export type CollectionSpacesCountChange = ReturnType<typeof collectionSpacesCountChange>;
-export type CollectionSpacesDelete = { type: typeof COLLECTION_SPACES_DELETE, item: CoreSpace };
-export type CollectionSpacesError = { type: typeof COLLECTION_SPACES_ERROR, error: Error | string };
+export type CollectionSpacesDelete = ReturnType<typeof collectionSpacesDelete>;
+export type CollectionSpacesError = ReturnType<typeof collectionSpacesError>;
 export type CollectionSpacesFilter = ReturnType<typeof collectionSpacesFilter>;
-export type CollectionSpacesPush = { type: typeof COLLECTION_SPACES_PUSH, item: CoreSpace };
+export type CollectionSpacesPush = ReturnType<typeof collectionSpacesPush>;
+export type CollectionSpacesSet = ReturnType<typeof collectionSpacesSet>;
 export type CollectionSpacesSetDefaultTimeRange = ReturnType<typeof collectionSpacesSetDefaultTimeRange>;
 export type CollectionSpacesSetEvents = ReturnType<typeof collectionSpacesSetEvents>;
 export type CollectionSpacesBatchSetEvents = ReturnType<typeof collectionSpacesBatchSetEvents>;
@@ -35,12 +35,12 @@ export type HideModal = { type: typeof HIDE_MODAL };
 export type UpdateModal = { type: typeof UPDATE_MODAL };
 
 export type ReduxAction = (
-  CollectionSpacesSet |
   CollectionSpacesCountChange |
   CollectionSpacesDelete |
   CollectionSpacesError |
   CollectionSpacesFilter |
   CollectionSpacesPush |
+  CollectionSpacesSet |
   CollectionSpacesSetDefaultTimeRange |
   CollectionSpacesSetEvents |
   CollectionSpacesBatchSetEvents |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -5,6 +5,7 @@ import { COLLECTION_SPACES_ERROR } from '../rx-actions/collection/spaces-legacy/
 import { COLLECTION_SPACES_PUSH } from '../rx-actions/collection/spaces-legacy/push';
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
+import collectionSpacesCountChange from '../rx-actions/collection/spaces-legacy/count-change';
 import collectionSpacesSetEvents, { collectionSpacesBatchSetEvents } from '../rx-actions/collection/spaces-legacy/set-events';
 import collectionSpacesSetDefaultTimeRange from '../rx-actions/collection/spaces-legacy/set-default-time-range';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
@@ -13,6 +14,7 @@ import { UPDATE_MODAL } from '../rx-actions/modal/update';
 import { AdminLocationsSpaceFieldUpdate } from '../rx-stores/space-management';
 
 export type CollectionSpacesSet = { type: typeof COLLECTION_SPACES_SET, data: Array<CoreSpace> };
+export type CollectionSpacesCountChange = ReturnType<typeof collectionSpacesCountChange>;
 export type CollectionSpacesDelete = { type: typeof COLLECTION_SPACES_DELETE, item: CoreSpace };
 export type CollectionSpacesError = { type: typeof COLLECTION_SPACES_ERROR, error: Error | string };
 export type CollectionSpacesPush = { type: typeof COLLECTION_SPACES_PUSH, item: CoreSpace };
@@ -32,6 +34,7 @@ export type UpdateModal = { type: typeof UPDATE_MODAL };
 
 export type ReduxAction = (
   CollectionSpacesSet |
+  CollectionSpacesCountChange |
   CollectionSpacesDelete |
   CollectionSpacesError |
   CollectionSpacesPush |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -1,6 +1,6 @@
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 import collectionSpacesSet from '../rx-actions/collection/spaces-legacy/set';
-import collectionSpacesDelete from '../rx-actions/collection/spaces-legacy/delete';
+import collectionSpacesDelete, { COLLECTION_SPACES_DELETE } from '../rx-actions/collection/spaces-legacy/delete';
 import collectionSpacesError from '../rx-actions/collection/spaces-legacy/error';
 import collectionSpacesPush from '../rx-actions/collection/spaces-legacy/push';
 import collectionSpacesCountChange from '../rx-actions/collection/spaces-legacy/count-change';
@@ -8,6 +8,7 @@ import collectionSpacesFilter from '../rx-actions/collection/spaces-legacy/filte
 import collectionSpacesSetEvents, { collectionSpacesBatchSetEvents } from '../rx-actions/collection/spaces-legacy/set-events';
 import collectionSpacesSetDefaultTimeRange from '../rx-actions/collection/spaces-legacy/set-default-time-range';
 import { COLLECTION_SPACES_CREATE } from '../rx-actions/collection/spaces-legacy/create';
+import { COLLECTION_SPACES_DESTROY } from '../rx-actions/collection/spaces-legacy/destroy';
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACES_RESET_COUNT } from '../rx-actions/collection/spaces-legacy/reset-count';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
@@ -27,6 +28,7 @@ export type CollectionSpacesSetEvents = ReturnType<typeof collectionSpacesSetEve
 export type CollectionSpacesBatchSetEvents = ReturnType<typeof collectionSpacesBatchSetEvents>;
 
 export type CollectionSpacesCreate = { type: typeof COLLECTION_SPACES_CREATE, item: AdminLocationsSpaceFormResult };
+export type CollectionSpacesDestroy = { type: typeof COLLECTION_SPACES_DESTROY, space: CoreSpace };
 export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFormResult };
 export type CollectionSpacesResetCount = { type: typeof COLLECTION_SPACES_RESET_COUNT, item: CoreSpace, newCount: number };
 
@@ -52,6 +54,7 @@ export type ReduxAction = (
   CollectionSpacesSetEvents |
   CollectionSpacesBatchSetEvents |
   CollectionSpacesCreate |
+  CollectionSpacesDestroy |
   CollectionSpacesUpdate |
   CollectionSpaceHierarchySet |
   TransitionToShowModal |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -6,6 +6,7 @@ import { COLLECTION_SPACES_PUSH } from '../rx-actions/collection/spaces-legacy/p
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
 import collectionSpacesSetEvents, { collectionSpacesBatchSetEvents } from '../rx-actions/collection/spaces-legacy/set-events';
+import collectionSpacesSetDefaultTimeRange from '../rx-actions/collection/spaces-legacy/set-default-time-range';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
 import { TRANSITION_TO_HIDE_MODAL, HIDE_MODAL } from '../rx-actions/modal/hide';
 import { UPDATE_MODAL } from '../rx-actions/modal/update';
@@ -15,6 +16,7 @@ export type CollectionSpacesSet = { type: typeof COLLECTION_SPACES_SET, data: Ar
 export type CollectionSpacesDelete = { type: typeof COLLECTION_SPACES_DELETE, item: CoreSpace };
 export type CollectionSpacesError = { type: typeof COLLECTION_SPACES_ERROR, error: Error | string };
 export type CollectionSpacesPush = { type: typeof COLLECTION_SPACES_PUSH, item: CoreSpace };
+export type CollectionSpacesSetDefaultTimeRange = ReturnType<typeof collectionSpacesSetDefaultTimeRange>;
 export type CollectionSpacesSetEvents = ReturnType<typeof collectionSpacesSetEvents>;
 export type CollectionSpacesBatchSetEvents = ReturnType<typeof collectionSpacesBatchSetEvents>;
 export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFieldUpdate };
@@ -33,6 +35,7 @@ export type ReduxAction = (
   CollectionSpacesDelete |
   CollectionSpacesError |
   CollectionSpacesPush |
+  CollectionSpacesSetDefaultTimeRange |
   CollectionSpacesSetEvents |
   CollectionSpacesBatchSetEvents |
   CollectionSpacesUpdate |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -7,12 +7,13 @@ import collectionSpacesCountChange from '../rx-actions/collection/spaces-legacy/
 import collectionSpacesFilter from '../rx-actions/collection/spaces-legacy/filter';
 import collectionSpacesSetEvents, { collectionSpacesBatchSetEvents } from '../rx-actions/collection/spaces-legacy/set-events';
 import collectionSpacesSetDefaultTimeRange from '../rx-actions/collection/spaces-legacy/set-default-time-range';
+import { COLLECTION_SPACES_CREATE } from '../rx-actions/collection/spaces-legacy/create';
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
 import { TRANSITION_TO_HIDE_MODAL, HIDE_MODAL } from '../rx-actions/modal/hide';
 import { UPDATE_MODAL } from '../rx-actions/modal/update';
-import { AdminLocationsSpaceFieldUpdate } from '../rx-stores/space-management';
+import { AdminLocationsSpaceFormResult } from '../rx-stores/space-management';
 
 export type CollectionSpacesCountChange = ReturnType<typeof collectionSpacesCountChange>;
 export type CollectionSpacesDelete = ReturnType<typeof collectionSpacesDelete>;
@@ -23,7 +24,10 @@ export type CollectionSpacesSet = ReturnType<typeof collectionSpacesSet>;
 export type CollectionSpacesSetDefaultTimeRange = ReturnType<typeof collectionSpacesSetDefaultTimeRange>;
 export type CollectionSpacesSetEvents = ReturnType<typeof collectionSpacesSetEvents>;
 export type CollectionSpacesBatchSetEvents = ReturnType<typeof collectionSpacesBatchSetEvents>;
-export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFieldUpdate };
+
+export type CollectionSpacesCreate = { type: typeof COLLECTION_SPACES_CREATE, item: AdminLocationsSpaceFormResult };
+export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFormResult };
+
 export type CollectionSpaceHierarchySet = { type: typeof COLLECTION_SPACE_HIERARCHY_SET, data: Array<CoreSpace> };
 
 export type TransitionToShowModal = { type: typeof TRANSITION_TO_SHOW_MODAL, name: string, data: object };
@@ -44,6 +48,7 @@ export type ReduxAction = (
   CollectionSpacesSetDefaultTimeRange |
   CollectionSpacesSetEvents |
   CollectionSpacesBatchSetEvents |
+  CollectionSpacesCreate |
   CollectionSpacesUpdate |
   CollectionSpaceHierarchySet |
   TransitionToShowModal |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -5,6 +5,7 @@ import { COLLECTION_SPACES_ERROR } from '../rx-actions/collection/spaces-legacy/
 import { COLLECTION_SPACES_PUSH } from '../rx-actions/collection/spaces-legacy/push';
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
+import collectionSpacesSetEvents, { collectionSpacesBatchSetEvents } from '../rx-actions/collection/spaces-legacy/set-events';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
 import { TRANSITION_TO_HIDE_MODAL, HIDE_MODAL } from '../rx-actions/modal/hide';
 import { UPDATE_MODAL } from '../rx-actions/modal/update';
@@ -14,6 +15,8 @@ export type CollectionSpacesSet = { type: typeof COLLECTION_SPACES_SET, data: Ar
 export type CollectionSpacesDelete = { type: typeof COLLECTION_SPACES_DELETE, item: CoreSpace };
 export type CollectionSpacesError = { type: typeof COLLECTION_SPACES_ERROR, error: Error | string };
 export type CollectionSpacesPush = { type: typeof COLLECTION_SPACES_PUSH, item: CoreSpace };
+export type CollectionSpacesSetEvents = ReturnType<typeof collectionSpacesSetEvents>;
+export type CollectionSpacesBatchSetEvents = ReturnType<typeof collectionSpacesBatchSetEvents>;
 export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFieldUpdate };
 export type CollectionSpaceHierarchySet = { type: typeof COLLECTION_SPACE_HIERARCHY_SET, data: Array<CoreSpace> };
 
@@ -30,6 +33,8 @@ export type ReduxAction = (
   CollectionSpacesDelete |
   CollectionSpacesError |
   CollectionSpacesPush |
+  CollectionSpacesSetEvents |
+  CollectionSpacesBatchSetEvents |
   CollectionSpacesUpdate |
   CollectionSpaceHierarchySet |
   TransitionToShowModal |

--- a/src/types/redux.ts
+++ b/src/types/redux.ts
@@ -1,6 +1,8 @@
 import { CoreSpace } from '@density/lib-api-types/core-v2/spaces';
 import { COLLECTION_SPACES_SET } from '../rx-actions/collection/spaces-legacy/set';
+import { COLLECTION_SPACES_DELETE } from '../rx-actions/collection/spaces-legacy/delete';
 import { COLLECTION_SPACES_ERROR } from '../rx-actions/collection/spaces-legacy/error';
+import { COLLECTION_SPACES_PUSH } from '../rx-actions/collection/spaces-legacy/push';
 import { COLLECTION_SPACES_UPDATE } from '../rx-actions/collection/spaces-legacy/update';
 import { COLLECTION_SPACE_HIERARCHY_SET } from '../rx-actions/collection/space-hierarchy/set';
 import { TRANSITION_TO_SHOW_MODAL, SHOW_MODAL } from '../rx-actions/modal/show';
@@ -9,8 +11,10 @@ import { UPDATE_MODAL } from '../rx-actions/modal/update';
 import { AdminLocationsSpaceFieldUpdate } from '../rx-stores/space-management';
 
 export type CollectionSpacesSet = { type: typeof COLLECTION_SPACES_SET, data: Array<CoreSpace> };
+export type CollectionSpacesDelete = { type: typeof COLLECTION_SPACES_DELETE, item: CoreSpace };
 export type CollectionSpacesError = { type: typeof COLLECTION_SPACES_ERROR, error: Error | string };
-export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFieldUpdate }
+export type CollectionSpacesPush = { type: typeof COLLECTION_SPACES_PUSH, item: CoreSpace };
+export type CollectionSpacesUpdate = { type: typeof COLLECTION_SPACES_UPDATE, item: AdminLocationsSpaceFieldUpdate };
 export type CollectionSpaceHierarchySet = { type: typeof COLLECTION_SPACE_HIERARCHY_SET, data: Array<CoreSpace> };
 
 export type TransitionToShowModal = { type: typeof TRANSITION_TO_SHOW_MODAL, name: string, data: object };
@@ -23,7 +27,9 @@ export type UpdateModal = { type: typeof UPDATE_MODAL };
 
 export type ReduxAction = (
   CollectionSpacesSet |
+  CollectionSpacesDelete |
   CollectionSpacesError |
+  CollectionSpacesPush |
   CollectionSpacesUpdate |
   CollectionSpaceHierarchySet |
   TransitionToShowModal |


### PR DESCRIPTION
### SpacesLegacyStore
- added types to former Any fields
- removed unused filter fields
### rx-actions/collection/spaces-legacy
- added types for all spaces-legacy actions
- ensured all these actions make it into GlobalAction 🎉 

This looks like a big changeset, but it's almost entirely type annotations. I made a couple callouts in the notes below.